### PR TITLE
Add snapshot download support to Docker

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -2,7 +2,7 @@ GENESIS_FILE_PATH=mainnet/genesis.json
 SEQUENCER_HTTP=https://rpc.api.lisk.com
 RETH_CHAIN=lisk
 
-APPLY_SNAPSHOT=false
+APPLY_SNAPSHOT=${APPLY_SNAPSHOT:-false}
 SNAPSHOT_URL=http://snapshots.lisk.com/mainnet/geth-snapshot
 
 # [optional] used to enable geth stats:

--- a/.env.mainnet
+++ b/.env.mainnet
@@ -2,6 +2,9 @@ GENESIS_FILE_PATH=mainnet/genesis.json
 SEQUENCER_HTTP=https://rpc.api.lisk.com
 RETH_CHAIN=lisk
 
+APPLY_SNAPSHOT=false
+SNAPSHOT_URL=http://snapshots.lisk.com/mainnet/geth-snapshot
+
 # [optional] used to enable geth stats:
 # OP_GETH_ETH_STATS=nodename:secret@host:port
 

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -3,6 +3,9 @@ SEQUENCER_HTTP=https://rpc.sepolia-api.lisk.com
 OP_NODE_OVERRIDE_CANYON=0
 RETH_CHAIN=lisk-sepolia
 
+APPLY_SNAPSHOT=false
+SNAPSHOT_URL=http://snapshots.lisk.com/sepolia/geth-snapshot
+
 # [optional] used to enable geth stats:
 # OP_GETH_ETH_STATS=nodename:secret@host:port
 

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -3,7 +3,7 @@ SEQUENCER_HTTP=https://rpc.sepolia-api.lisk.com
 OP_NODE_OVERRIDE_CANYON=0
 RETH_CHAIN=lisk-sepolia
 
-APPLY_SNAPSHOT=false
+APPLY_SNAPSHOT=${APPLY_SNAPSHOT:-false}
 SNAPSHOT_URL=http://snapshots.lisk.com/sepolia/geth-snapshot
 
 # [optional] used to enable geth stats:

--- a/README.md
+++ b/README.md
@@ -143,8 +143,7 @@ For, Lisk Sepolia Testnet:
     --rollup.sequencerhttp=SEQUENCER_HTTP \
     --rollup.halt=major \
     --port=30303 \
-    --rollup.disabletxpoolgossip=true \
-    --override.canyon=0
+    --rollup.disabletxpoolgossip=true
 ```
 
 For, Lisk Mainnet:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository contains information on how to run your own node on the Lisk net
 
 ## System requirements
 
-The following system requirements are recommended to run Lisk L2 node.
+The following system requirements are recommended to run a Lisk L2 node.
 
 ### Memory
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ For more information refer to the OP [documentation](https://docs.optimism.io/bu
 
 #### Initialize op-geth
 
+> **Important**: If you already had your node running prior to the Fjord upgrade (Mainnet: July 10, 2024 & Sepolia: May 29, 2024), please make sure to re-initialize your data directory with the updated genesis block. This is automatically taken care of for the Docker users.
+
 Navigate to your `op-geth` directory and initialize the service by running the command:
 
 ```sh
@@ -268,9 +270,34 @@ Refer to the `op-node` configuration [documentation](https://docs.optimism.io/bu
 
 ## Snapshots
 
-TBA
+> **Note**: Currently, snapshots are only available for the `op-geth` client and are **NOT** regularly updated. We are currently working on improving this.
 
-### Syncing
+### Docker
+
+To enable auto-snapshot download and application, please set the `APPLY_SNAPSHOT` environment variable to `true` when starting the node.
+```sh
+APPLY_SNAPSHOT=true docker compose up --build --detach
+```
+
+### Source
+
+Please follow the steps below:
+
+- Download the snapshot and the corresponding checksum from. The latest snapshot is always named `geth-snapshot`:
+  - Mainnet: https://snapshots.lisk.com/mainnet
+  - Sepolia: https://snapshots.lisk.com/sepolia
+
+- Verify the integrity of the downloaded snapshot with:
+  ```sh
+  sha256sum -c <checksum-file-name>
+  ```
+
+- Import the snapshot
+  ```sh
+  ./build/bin/geth import --datadir=$GETH_DATA_DIR <path-to-snapshot>
+  ```
+
+## Syncing
 
 Sync speed depends on your L1 node, as the majority of the chain is derived from data submitted to the L1. You can check your syncing status using the `optimism_syncStatus` RPC on the `op-node` container. Example:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       # select your network here:
       #   - .env.sepolia
       - .env.mainnet
+    environment:
+      - APPLY_SNAPSHOT=$APPLY_SNAPSHOT
   node:
     platform: linux/amd64
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       # select your network here:
       #   - .env.sepolia
       - .env.mainnet
-    environment:
-      - APPLY_SNAPSHOT=$APPLY_SNAPSHOT
   node:
     platform: linux/amd64
     build:

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -41,6 +41,7 @@ COPY --from=op /app/op-node/bin/op-node ./
 COPY --from=geth /app/build/bin/geth ./
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY geth/geth-entrypoint ./execution-entrypoint
+COPY geth/download-apply-snapshot.sh .
 COPY op-node-entrypoint .
 COPY sepolia ./sepolia
 COPY mainnet ./mainnet

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 as op
+FROM golang:1.21 AS op
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ RUN git apply lisk-hotfix.patch && \
     cd op-node && \
     make VERSION=$VERSION op-node
 
-FROM golang:1.21 as geth
+FROM golang:1.21 AS geth
 
 WORKDIR /app
 

--- a/geth/download-apply-snapshot.sh
+++ b/geth/download-apply-snapshot.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -eu
+
+# Set alias for echoBanner if unavailable - for local testing
+[[ $(type -t echoBanner) == function ]] || alias echoBanner=echo
+
+# Translate APPLY_SNAPSHOT to uppercase; default to FALSE
+APPLY_SNAPSHOT=$(echo "${APPLY_SNAPSHOT-false}" | tr "[:lower:]" "[:upper:]")
+
+if [[ "$APPLY_SNAPSHOT" == "FALSE" ]]; then
+  echo "Automatic snapshot application disabled; to enable, set 'APPLY_SNAPSHOT=true' and restart"
+  exit 0
+fi
+
+if [[ "${SNAPSHOT_URL-x}" == x || -z $SNAPSHOT_URL ]]; then
+    echo "APPLY_SNAPSHOT enabled but SNAPSHOT_URL is undefined"
+    exit 1
+fi
+
+if [[ "${GETH_DATA_DIR-x}" == x ]]; then
+    echo "GETH_DATA_DIR is undefined"
+    exit 2
+fi
+
+SNAPSHOT_DIR=./snapshot
+SNAPSHOT_FILENAME=$(basename ${SNAPSHOT_URL})
+SNAPSHOT_SHA256_URL="${SNAPSHOT_URL}.SHA256"
+SNAPSHOT_SHA256_FILENAME="${SNAPSHOT_FILENAME}.SHA256"
+
+# Clear any existing snapshots
+rm -rf $SNAPSHOT_DIR
+
+# Download the snapshot & the checksum file
+echoBanner "Downloading snapshot to '${SNAPSHOT_DIR}/$SNAPSHOT_FILENAME' from '${SNAPSHOT_URL}'..."
+curl --create-dirs --output $SNAPSHOT_DIR/$SNAPSHOT_FILENAME --location $SNAPSHOT_URL
+curl --create-dirs --output $SNAPSHOT_DIR/$SNAPSHOT_SHA256_FILENAME --location $SNAPSHOT_SHA256_URL
+
+echoBanner "Verifying integrity of the downloaded snapshot..."
+if command -v sha256sum &>/dev/null; then
+  (cd $SNAPSHOT_DIR && sha256sum --check $SNAPSHOT_SHA256_FILENAME &>/dev/null)
+elif command -v shasum &>/dev/null; then
+  (cd $SNAPSHOT_DIR && shasum --algorithm 256 --check $SNAPSHOT_SHA256_FILENAME &>/dev/null)
+else
+  echo "Neither sha256sum nor shasum available. Skipping..."
+  exit 9
+fi
+
+if [[ "$?" == "0" ]]; then
+  echo "Snapshot successfully downloaded and verified"
+else
+  echo "Snapshot is corrupted. Skipping snapshot application..."
+  exit 10
+fi
+
+# Import snapshot
+echoBanner "Importing snapshot..."
+./geth import --datadir=$GETH_DATA_DIR $SNAPSHOT_DIR/$SNAPSHOT_FILENAME
+if [[ "$?" == "0" ]]; then
+  echo "Snapshot successfully imported"
+else
+  echo "Snapshot import failed. Skipping snapshot application..."
+  exit 11
+fi

--- a/geth/download-apply-snapshot.sh
+++ b/geth/download-apply-snapshot.sh
@@ -5,7 +5,7 @@ set -eu
 [[ $(type -t echoBanner) == function ]] || alias echoBanner=echo
 
 # Translate APPLY_SNAPSHOT to uppercase; default to FALSE
-APPLY_SNAPSHOT=$(echo "${APPLY_SNAPSHOT-false}" | tr "[:lower:]" "[:upper:]")
+readonly APPLY_SNAPSHOT=$(echo "${APPLY_SNAPSHOT:-false}" | tr "[:lower:]" "[:upper:]")
 
 if [[ "$APPLY_SNAPSHOT" == "FALSE" ]]; then
   echo "Automatic snapshot application disabled; to enable, set 'APPLY_SNAPSHOT=true' and restart"
@@ -22,39 +22,50 @@ if [[ "${GETH_DATA_DIR-x}" == x ]]; then
     exit 2
 fi
 
-SNAPSHOT_DIR=./snapshot
-SNAPSHOT_FILENAME=$(basename ${SNAPSHOT_URL})
-SNAPSHOT_SHA256_URL="${SNAPSHOT_URL}.SHA256"
-SNAPSHOT_SHA256_FILENAME="${SNAPSHOT_FILENAME}.SHA256"
+readonly SNAPSHOT_DIR=./snapshot
+readonly SNAPSHOT_FILENAME=$(basename ${SNAPSHOT_URL})
+readonly SNAPSHOT_SHA256_URL="${SNAPSHOT_URL}.SHA256"
+readonly SNAPSHOT_SHA256_FILENAME="${SNAPSHOT_FILENAME}.SHA256"
+readonly SNAPSHOT_DOWNLOAD_MAX_TRIES=3
 
 # Clear any existing snapshots
 rm -rf $SNAPSHOT_DIR
 
 # Download the snapshot & the checksum file
 echoBanner "Downloading snapshot to '${SNAPSHOT_DIR}/$SNAPSHOT_FILENAME' from '${SNAPSHOT_URL}'..."
-curl --create-dirs --output $SNAPSHOT_DIR/$SNAPSHOT_FILENAME --location $SNAPSHOT_URL
-curl --create-dirs --output $SNAPSHOT_DIR/$SNAPSHOT_SHA256_FILENAME --location $SNAPSHOT_SHA256_URL
+num_tries_left=$SNAPSHOT_DOWNLOAD_MAX_TRIES
+download_and_verify(){
+  echo -e "Number of tries left: ${num_tries_left}"
+  : $((--num_tries_left)) # Reduce num_tries_left
 
-echoBanner "Verifying integrity of the downloaded snapshot..."
-if command -v sha256sum &>/dev/null; then
-  (cd $SNAPSHOT_DIR && sha256sum --check $SNAPSHOT_SHA256_FILENAME &>/dev/null)
-elif command -v shasum &>/dev/null; then
-  (cd $SNAPSHOT_DIR && shasum --algorithm 256 --check $SNAPSHOT_SHA256_FILENAME &>/dev/null)
-else
-  echo "Neither sha256sum nor shasum available. Skipping..."
-  exit 9
-fi
+  echo -e "\nDownloading snapshot..."
+  curl --create-dirs --output $SNAPSHOT_DIR/$SNAPSHOT_FILENAME --location $SNAPSHOT_URL
 
-if [[ "$?" == "0" ]]; then
+  echo -e "\nDownloading snapshot checksum..."
+  curl --create-dirs --output $SNAPSHOT_DIR/$SNAPSHOT_SHA256_FILENAME --location $SNAPSHOT_SHA256_URL
+
+  echo -e "\nVerifying integrity of the downloaded snapshot..."
+  if command -v sha256sum &>/dev/null; then
+    (cd $SNAPSHOT_DIR && sha256sum --check $SNAPSHOT_SHA256_FILENAME &>/dev/null)
+  elif command -v shasum &>/dev/null; then
+    (cd $SNAPSHOT_DIR && shasum --algorithm 256 --check $SNAPSHOT_SHA256_FILENAME &>/dev/null)
+  else
+    echo "Neither sha256sum nor shasum available. Skipping..."
+    return 9
+  fi
+
+  if [[ "$?" != "0" ]]; then
+    echo "Snapshot is corrupted. Skipping snapshot application..."
+    return 10
+  fi
+
   echo "Snapshot successfully downloaded and verified"
-else
-  echo "Snapshot is corrupted. Skipping snapshot application..."
-  exit 10
-fi
+}
+for i in $(seq 1 $SNAPSHOT_DOWNLOAD_MAX_TRIES); do download_and_verify && returncode=0 && break || returncode=$? && sleep 10; done; (exit $returncode)
 
 # Import snapshot
 echoBanner "Importing snapshot..."
-./geth import --datadir=$GETH_DATA_DIR $SNAPSHOT_DIR/$SNAPSHOT_FILENAME
+./geth import --syncmode "${OP_GETH_SYNCMODE:-full}" --datadir=$GETH_DATA_DIR $SNAPSHOT_DIR/$SNAPSHOT_FILENAME
 if [[ "$?" == "0" ]]; then
   echo "Snapshot successfully imported"
 else

--- a/geth/geth-entrypoint
+++ b/geth/geth-entrypoint
@@ -55,10 +55,6 @@ fi
 
 if [ "${HOST_IP:+x}" = x ]; then
 	ADDITIONAL_ARGS="$ADDITIONAL_ARGS --nat=extip:$HOST_IP"
-fi 
-
-if [ "${OP_NODE_OVERRIDE_CANYON+x}" = x ]; then
-    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --override.canyon=$OP_NODE_OVERRIDE_CANYON"
 fi
 
 # Start service

--- a/geth/geth-entrypoint
+++ b/geth/geth-entrypoint
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -eu
 
+echoBanner() {
+	echo -e "\n------------------------------------------------------------------------------------------------------------"
+	echo -e "$@"
+	echo -e "------------------------------------------------------------------------------------------------------------\n"
+}
+
 VERBOSITY=${GETH_VERBOSITY:-3}
 GETH_DATA_DIR=/data
 RPC_PORT="${RPC_PORT:-8545}"
@@ -21,6 +27,14 @@ OP_GETH_SYNCMODE="${OP_GETH_SYNCMODE:-full}"
 
 mkdir -p $GETH_DATA_DIR
 
+# Init genesis
+echoBanner "Initializing data directory under '${GETH_DATA_DIR}'"
+./geth init --datadir=$GETH_DATA_DIR "$GENESIS_FILE_PATH"
+
+# Download and apply snapshot, when configured
+(. download-apply-snapshot.sh)
+
+# Set the start flags
 echo "$OP_NODE_L2_ENGINE_AUTH_RAW" > "$OP_NODE_L2_ENGINE_AUTH"
 
 if [ "${OP_GETH_ETH_STATS+x}" = x ]; then
@@ -47,10 +61,8 @@ if [ "${OP_NODE_OVERRIDE_CANYON+x}" = x ]; then
     ADDITIONAL_ARGS="$ADDITIONAL_ARGS --override.canyon=$OP_NODE_OVERRIDE_CANYON"
 fi
 
-# Init genesis
-./geth init --datadir=$GETH_DATA_DIR "$GENESIS_FILE_PATH"
-
 # Start service
+echoBanner "Starting node..."
 ./geth \
     --datadir="$GETH_DATA_DIR" \
     --verbosity="$VERBOSITY" \

--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -13,10 +13,6 @@ if [[ -z "$RETH_CHAIN" ]]; then
     exit 1
 fi
 
-if [ "${OP_NODE_OVERRIDE_CANYON+x}" = x ]; then
-    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --override.canyon=$OP_NODE_OVERRIDE_CANYON"
-fi
-
 mkdir -p $RETH_DATA_DIR
 echo "$OP_NODE_L2_ENGINE_AUTH_RAW" > "$OP_NODE_L2_ENGINE_AUTH"
 

--- a/sepolia/rollup.json
+++ b/sepolia/rollup.json
@@ -19,9 +19,9 @@
     }
   },
   "block_time": 2,
-  "delta_time": 0,
+  "delta_time": 1705312994,
   "fjord_time": 1716998400,
-  "canyon_time": 0,
+  "canyon_time": 1705312994,
   "l1_chain_id": 11155111,
   "l2_chain_id": 4202,
   "ecotone_time": 1708534800,


### PR DESCRIPTION
### What was the problem?

This PR resolves #25 

### How was it solved?

- [x] Added script to automatically download and apply snapshots
- [x] Added retry mechanism for snapshot on download failure
- [x] Updated the default environment files with the necessary flags with the default values
- [x] Updated README with relevant details
- [x] Patch/Update Lisk Sepolia genesis block and rollup config

### How was it tested?

Locally with `APPLY_SNAPSHOT=true docker compose -p lisk-node-snapshot up --build --detach`

### Additional Information

The `reth` image build issue due to which the CI is partially failing will be addressed with https://github.com/LiskHQ/lisk-node/issues/24. 