### PR TITLE
Bump op-node and op-geth versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The following system requirements are recommended to run a Lisk L2 node.
 
 > **Note**:
 > - It is currently not possible to run the nodes with the `--op-network` flag until the configs for Lisk have been merged to the [superchain-registry](https://github.com/ethereum-optimism/superchain-registry).
-> - Currently, due to ongoing changes in the above repo, addition of new chains to the registry have been paused. Once the maintenance is over, we will submit PRs to add the config for Lisk Mainnet and Lisk Sepolia.
+> - Currently, due to ongoing changes in the above repo, addition of new chains to the registry have been paused. Once the maintenance is over, we will submit PRs to add the config for both Lisk Sepolia and Lisk Mainnet.
 
 ### Clone the Repository
 
@@ -105,7 +105,7 @@ For more information refer to the OP [documentation](https://docs.optimism.io/bu
 
 #### Initialize op-geth
 
-> **Important**: If you already had your node running prior to the Fjord upgrade (Mainnet: July 10, 2024 & Sepolia: May 29, 2024), please make sure to re-initialize your data directory with the updated genesis block. This is automatically taken care of for the Docker users.
+> **Important**: If you already had your node running prior to the Fjord upgrade (Sepolia: May 29, 2024 & Mainnet: July 10, 2024), please make sure to re-initialize your data directory with the updated genesis block. This is automatically taken care of for the Docker users.
 
 Navigate to your `op-geth` directory and initialize the service by running the command:
 
@@ -189,8 +189,8 @@ Refer to the `reth` configuration [documentation](https://reth.rs/cli/reth/node.
 
 > **Note**:
 > <br>Official Lisk Sequencer HTTP RPC:
-> - **Lisk Mainnet**: https://rpc.sepolia-api.lisk.com
-> - **Lisk Sepolia**: https://rpc.api.lisk.com
+> - **Lisk Sepolia**: https://rpc.sepolia-api.lisk.com
+> - **Lisk Mainnet**: https://rpc.api.lisk.com
 
 #### Run op-node
 
@@ -239,8 +239,8 @@ APPLY_SNAPSHOT=true docker compose up --build --detach
 Please follow the steps below:
 
 - Download the snapshot and the corresponding checksum from. The latest snapshot is always named `geth-snapshot`:
-  - Mainnet: https://snapshots.lisk.com/mainnet
   - Sepolia: https://snapshots.lisk.com/sepolia
+  - Mainnet: https://snapshots.lisk.com/mainnet
 
 - Verify the integrity of the downloaded snapshot with:
   ```sh

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.21 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.7.7
-ENV COMMIT=f8143c8cbc4cc0c83922c53f17a1e47280673485
+ENV VERSION=v1.9.0
+ENV COMMIT=ec45f6634ab2855a4ae5d30c4e240d79f081d689
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -20,8 +20,8 @@ FROM golang:1.21 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101315.2
-ENV COMMIT=7c2819836018bfe0ca07c4e4955754834ffad4e0
+ENV VERSION=v1.101315.3
+ENV COMMIT=8af19cf20261c0b62f98cc27da3a268f542822ee
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

- This PR resolves #LISK-898.
- Small fixes inside README file.

### How was it solved?

- [x] Fixed README file.
- [x] Updated `op-node` to [v1.9.0](https://github.com/ethereum-optimism/optimism/releases/tag/v1.9.0) version.
- [x] Updated `op-geth` to [v1.101315.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101315.3) version.

### How was it tested?

Locally with `docker compose up --build --detach`.