### PR TITLE
Update `genesis.json` and `rollup.json` for Lisk Sepolia

### DIFF
--- a/sepolia/rollup.json
+++ b/sepolia/rollup.json
@@ -13,9 +13,7 @@
       "scalar": "0x00000000000000000000000000000000000000000000000000000000000f4240",
       "gasLimit": 30000000,
       "overhead": "0x0000000000000000000000000000000000000000000000000000000000000834",
-      "batcherAddr": "0x246e119a5bcc2875161b23e4e602e25cece96e37",
-      "basefeeScalar": 0,
-      "blobBasefeeScalar": 0
+      "batcherAddr": "0x246e119a5bcc2875161b23e4e602e25cece96e37"
     }
   },
   "block_time": 2,
@@ -25,11 +23,13 @@
   "l1_chain_id": 11155111,
   "l2_chain_id": 4202,
   "ecotone_time": 1708534800,
+  "granite_time": 1723478400,
   "regolith_time": 0,
   "channel_timeout": 300,
   "seq_window_size": 3600,
   "batch_inbox_address": "0xff00000000000000000000000000000000004202",
   "max_sequencer_drift": 600,
+  "channel_timeout_granite": 50,
   "deposit_contract_address": "0xe3d90f21490686ec7ef37be788e02dfc12787264",
   "l1_system_config_address": "0xf54791059df4a12ba461b881b4080ae81a1d0ac0",
   "protocol_versions_address": "0x0000000000000000000000000000000000000000"


### PR DESCRIPTION
### What was the problem?

Due to Granite hardfork upgrade for Sepolia network, `genesis.json` and `rollup.json` files needs to be updated for Lisk Sepolia network.

### How was it solved?

`genesis.json` and `rollup.json` were updated according to Granite hardfork upgrade.

### How was it tested?

Locally with `docker compose up --build --detach` using `Sepolia` network.
