### PR TITLE
Bump reth client to support Granite HF

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cd lisk-node
   - [jq](https://jqlang.github.io/jq/)
 
 - To build `op-node` and `op-geth` from source, follow the OP [documentation](https://docs.optimism.io/builders/node-operators/tutorials/node-from-source).
-  - Before building the `op-node`, please patch the code with [`lisk-hotfix.patch`](./geth/lisk-hotfix.patch) for an unhandled `SystemConfig` event emitted, affecting Lisk nodes resulting in errors.
+  - Before building the `op-node`, please patch the code with [`lisk-hotfix.patch`](./geth/lisk-hotfix.patch) for an unhandled `SystemConfig` event emitted on Lisk Sepolia, resulting in errors on the Lisk nodes.
     ```sh
     git apply <path-to-lisk-hotfix.patch>
     ```

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
 
 # Patch to handle the legacy ConfigUpdate event GAS_CONFIG_ECOTONE that shouldn't be used anymore
-# Only emitted by SystemConfig contract on Lisk Sepolia
+# Emitted only on Lisk Sepolia from the SystemConfig contract
 COPY op-node-lisk-hotfix.patch .
 RUN git apply op-node-lisk-hotfix.patch && \
     cd op-node && \

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -10,13 +10,13 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
 
 # Patch to handle the legacy ConfigUpdate event GAS_CONFIG_ECOTONE that shouldn't be used anymore
-# Only emitted by SystemConfig contract on Lisk Sepolia
+# Emitted only on Lisk Sepolia from the SystemConfig contract
 COPY op-node-lisk-hotfix.patch .
 RUN git apply op-node-lisk-hotfix.patch && \
     cd op-node && \
     make VERSION=$VERSION op-node
 
-FROM rust:1.79 AS reth
+FROM rust:1.80 AS reth
 
 ARG FEATURES=jemalloc,asm-keccak,optimism
 ARG PROFILE=release
@@ -26,11 +26,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.0.4
-ENV COMMIT=e24e4c773d7571a5a54dba7854643c02d0b0a841
-RUN git clone $REPO --branch $VERSION --single-branch . && \
-    git switch -c branch-$VERSION && \
-    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
+ENV COMMIT=ffd71a0b024e6c20f15cb95bcdf1b4882fc91093
+RUN git clone $REPO . && git checkout $COMMIT
 
 RUN cargo build --bin op-reth --locked --features $FEATURES --profile $PROFILE
 


### PR DESCRIPTION
### What was the problem?

This PR resolves LISK-910

### How was it solved?

- [x] Bump reth version to support Granite HF

### How was it tested?

Locally:
- `CLIENT=reth docker compose up --build --detach`
- `CLIENT=reth RETH_BUILD_PROFILE=maxperf docker compose up --build --detach`

```
ts=2024-08-12T06:35:22.892619842Z level=info target=reth::cli message="\nPre-merge hard forks (block based):\n- Homestead                        @0\n- Tangerine                        @0\n- SpuriousDragon                   @0\n- Byzantium                        @0\n- Constantinople                   @0\n- Petersburg                       @0\n- Istanbul                         @0\n- MuirGlacier                      @0\n- Berlin                           @0\n- London                           @0\n- ArrowGlacier                     @0\n- GrayGlacier                      @0\n- Bedrock                          @0\nMerge hard forks:\n- Paris                            @0 (network is known to be merged)\nPost-merge hard forks (timestamp based):\n- Shanghai                         @1705312994\n- Cancun                           @1708534800\n- Regolith                         @0\n- Canyon                           @1705312994\n- Ecotone                          @1708534800\n- Fjord                            @1716998400\n- Granite                          @1723478400"
```