### PR TITLE
Bump Reth client to v1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The following system requirements are recommended to run a Lisk L2 node.
 
 - Machines with a high performance SSD drive with at least 750GB (full node) or 4.5TB (archive node) free
 
+### Docker
+
+- Docker Engine version [27.0.1](https://docs.docker.com/engine/release-notes/27.0/) or higher
+
 ## Supported networks
 
 | Network      | Status |

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -26,8 +26,11 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV COMMIT=ffd71a0b024e6c20f15cb95bcdf1b4882fc91093
-RUN git clone $REPO . && git checkout $COMMIT
+ENV VERSION=v1.0.5
+ENV COMMIT=603e39ab74509e0863fc023461a4c760fb2126d1
+RUN git clone $REPO --branch $VERSION --single-branch . && \
+    git switch -c branch-$VERSION && \
+    bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
 
 RUN cargo build --bin op-reth --locked --features $FEATURES --profile $PROFILE
 


### PR DESCRIPTION
### What was the problem?

This PR resolves LISK-956

### How was it solved?

- [x] Bump Reth version to `1.0.5`

### How was it tested?

Locally:
- `CLIENT=reth RETH_BUILD_PROFILE=release docker compose up --build --detach`

```
2024-08-16 10:44:25 ts=2024-08-16T08:44:25.323050921Z level=info target=reth::cli message="Starting reth" version="\"1.0.5 (603e39ab)\""
```