### PR TITLE
Upgrade clients to support granite hard fork

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.21 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.0
-ENV COMMIT=ec45f6634ab2855a4ae5d30c4e240d79f081d689
+ENV VERSION=v1.9.1
+ENV COMMIT=4797ddb70e05d4952685bad53e608cb5606284e6
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,8 +21,8 @@ FROM golang:1.21 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101315.3
-ENV COMMIT=8af19cf20261c0b62f98cc27da3a268f542822ee
+ENV VERSION=v1.101408.0
+ENV COMMIT=5c2e75862239c77d2873de1888ba52ee84c83178
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/mainnet/rollup.json
+++ b/mainnet/rollup.json
@@ -23,6 +23,7 @@
   "l1_chain_id": 1,
   "l2_chain_id": 1135,
   "ecotone_time": 0,
+  "granite_time": 1726070401,
   "regolith_time": 0,
   "channel_timeout": 300,
   "seq_window_size": 3600,

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.21 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.0
-ENV COMMIT=ec45f6634ab2855a4ae5d30c4e240d79f081d689
+ENV VERSION=v1.9.1
+ENV COMMIT=4797ddb70e05d4952685bad53e608cb5606284e6
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -26,8 +26,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.0.5
-ENV COMMIT=603e39ab74509e0863fc023461a4c760fb2126d1
+ENV VERSION=v1.0.6
+ENV COMMIT=c228fe15808c3acbf18dc3af1a03ef5cbdcda07a
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1031

### How was it solved?
 - Bump op-node to v1.9.1
 - Bump op-geth to v1.101408.0
 - Bump reth to v1.0.6
### How was it tested?
Locally with
- `docker compose up --build --detach`
- `CLIENT=reth RETH_BUILD_PROFILE=release docker compose up --build --detach`
