### PR TITLE
Add datadir snapshot download support

### DIFF
--- a/geth/download-apply-snapshot.sh
+++ b/geth/download-apply-snapshot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -u
 
 # Set alias for echoBanner if unavailable - for local testing
 [[ $(type -t echoBanner) == function ]] || alias echoBanner=echo
@@ -13,33 +13,33 @@ if [[ "$APPLY_SNAPSHOT" == "FALSE" ]]; then
 fi
 
 if [[ "${SNAPSHOT_URL-x}" == x || -z $SNAPSHOT_URL ]]; then
-    echo "APPLY_SNAPSHOT enabled but SNAPSHOT_URL is undefined"
-    exit 1
+  echo "APPLY_SNAPSHOT enabled but SNAPSHOT_URL is undefined"
+  exit 1
 fi
 
 if [[ "${GETH_DATA_DIR-x}" == x ]]; then
-    echo "GETH_DATA_DIR is undefined"
-    exit 2
+  echo "GETH_DATA_DIR is undefined"
+  exit 2
 fi
 
 readonly SNAPSHOT_DIR=./snapshot
-readonly SNAPSHOT_FILENAME=$(basename ${SNAPSHOT_URL})
+readonly SNAPSHOT_REMOTE_FILENAME=$(basename ${SNAPSHOT_URL})
 readonly SNAPSHOT_SHA256_URL="${SNAPSHOT_URL}.SHA256"
-readonly SNAPSHOT_SHA256_FILENAME="${SNAPSHOT_FILENAME}.SHA256"
+readonly SNAPSHOT_SHA256_FILENAME="${SNAPSHOT_REMOTE_FILENAME}.SHA256"
 readonly SNAPSHOT_DOWNLOAD_MAX_TRIES=3
 
 # Clear any existing snapshots
 rm -rf $SNAPSHOT_DIR
 
 # Download the snapshot & the checksum file
-echoBanner "Downloading snapshot to '${SNAPSHOT_DIR}/$SNAPSHOT_FILENAME' from '${SNAPSHOT_URL}'..."
+echoBanner "Downloading snapshot to '${SNAPSHOT_DIR}/${SNAPSHOT_REMOTE_FILENAME}' from '${SNAPSHOT_URL}'..."
 num_tries_left=$SNAPSHOT_DOWNLOAD_MAX_TRIES
 download_and_verify(){
   echo -e "Number of tries left: ${num_tries_left}"
   : $((--num_tries_left)) # Reduce num_tries_left
 
   echo -e "\nDownloading snapshot..."
-  curl --create-dirs --output $SNAPSHOT_DIR/$SNAPSHOT_FILENAME --location $SNAPSHOT_URL
+  curl --create-dirs --output $SNAPSHOT_DIR/$SNAPSHOT_REMOTE_FILENAME --location $SNAPSHOT_URL
 
   echo -e "\nDownloading snapshot checksum..."
   curl --create-dirs --output $SNAPSHOT_DIR/$SNAPSHOT_SHA256_FILENAME --location $SNAPSHOT_SHA256_URL
@@ -63,12 +63,33 @@ download_and_verify(){
 }
 for i in $(seq 1 $SNAPSHOT_DOWNLOAD_MAX_TRIES); do download_and_verify && returncode=0 && break || returncode=$? && sleep 10; done; (exit $returncode)
 
+# Extract if the downloaded snapshot file is a tarball
+if [[ $SNAPSHOT_REMOTE_FILENAME == *.tar.gz ]]; then
+  readonly SNAPSHOT_FILENAME=$(tar -tf ${SNAPSHOT_DIR}/${SNAPSHOT_REMOTE_FILENAME})
+
+  echo -e "\nExtracting the snapshot tarball to '${SNAPSHOT_DIR}/${SNAPSHOT_FILENAME}'"
+  tar --directory $SNAPSHOT_DIR -xf $SNAPSHOT_DIR/$SNAPSHOT_REMOTE_FILENAME
+  if [[ "$?" == "0" ]]; then
+    echo "Successfully extracted the snapshot tarball"
+  else
+    echo "Tarball extraction failed. Skipping snapshot application..."
+    exit 11
+  fi
+else
+  readonly SNAPSHOT_FILENAME=${SNAPSHOT_REMOTE_FILENAME}
+fi
+
 # Import snapshot
 echoBanner "Importing snapshot..."
 ./geth import --syncmode "${OP_GETH_SYNCMODE:-full}" --datadir=$GETH_DATA_DIR $SNAPSHOT_DIR/$SNAPSHOT_FILENAME
-if [[ "$?" == "0" ]]; then
+readonly SNAPSHOT_IMPORT_EXIT_CODE=$?
+
+echo -e "\nRemoving the temporary snapshot download directory: '${SNAPSHOT_DIR}'"
+rm -rf $SNAPSHOT_DIR
+
+if [[ "$SNAPSHOT_IMPORT_EXIT_CODE" == "0" ]]; then
   echo "Snapshot successfully imported"
 else
   echo "Snapshot import failed. Skipping snapshot application..."
-  exit 11
+  exit 12
 fi

--- a/geth/download-apply-snapshot.sh
+++ b/geth/download-apply-snapshot.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set +e
 set -u
 
 # Set alias for echoBanner if unavailable - for local testing


### PR DESCRIPTION
### What was the problem?

This PR resolves [LISK-968](https://onchaincollective.atlassian.net/browse/LISK-968)

### How was it solved?

- Update the geth/download-apply-snapshot.sh script to support:
  - [x] Snapshot export tarball
  - [x] Data directory snapshot tarball

### How was it tested?

Update `SNAPSHOT_URL` in `.env.*` files to point to export/datadir snapshot tarballs and run `APPLY_SNAPSHOT=true docker compose up --build --detach`


[LISK-968]: https://onchaincollective.atlassian.net/browse/LISK-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ