### PR TITLE
Update PR workflow to use the linux-arm64 runner

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,57 +4,53 @@ on:
   pull_request:
 
 jobs:
-  amd64:
+  linux_amd64:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - arch: linux/amd64
-            file: geth/Dockerfile
+          - file: geth/Dockerfile
             features: 
-          - arch: linux/amd64
-            file: reth/Dockerfile
+          - file: reth/Dockerfile
             features: jemalloc,asm-keccak,optimism
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build the Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.file }}
           push: false
           build-args: |
             FEATURES=${{ matrix.features }}
-          platforms: ${{ matrix.arch }}
-  arm64:
+          platforms: linux/amd64
+  linux_arm64:
     runs-on: linux-arm64
     strategy:
       matrix:
         include:
-          - arch: linux/arm64
-            file: geth/Dockerfile
+          - file: geth/Dockerfile
             features: 
-          - arch: linux/arm64
-            file: reth/Dockerfile
+          - file: reth/Dockerfile
             features: jemalloc,optimism
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build the Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.file }}
           push: false
           build-args: |
             FEATURES=${{ matrix.features }}
-          platforms: ${{ matrix.arch }}
+          platforms: linux/arm64

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,11 +4,17 @@ on:
   pull_request:
 
 jobs:
-  geth:
+  amd64:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [ linux/amd64, linux/arm64 ]
+        include:
+          - arch: linux/amd64
+            file: geth/Dockerfile
+            features: 
+          - arch: linux/amd64
+            file: reth/Dockerfile
+            features: jemalloc,asm-keccak,optimism
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -20,17 +26,21 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: geth/Dockerfile
+          file: ${{ matrix.file }}
           push: false
+          build-args: |
+            FEATURES=${{ matrix.features }}
           platforms: ${{ matrix.arch }}
-  reth:
-    runs-on: ubuntu-latest
+  arm64:
+    runs-on: linux-arm64
     strategy:
       matrix:
         include:
-          - arch: linux/amd64
-            features: jemalloc,asm-keccak,optimism
           - arch: linux/arm64
+            file: geth/Dockerfile
+            features: 
+          - arch: linux/arm64
+            file: reth/Dockerfile
             features: jemalloc,optimism
     steps:
       - name: Checkout
@@ -43,7 +53,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: reth/Dockerfile
+          file: ${{ matrix.file }}
           push: false
           build-args: |
             FEATURES=${{ matrix.features }}

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.21 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.2
-ENV COMMIT=224c5fd65cb4e8204258291e74263c1e70466176
+ENV VERSION=v1.9.3
+ENV COMMIT=e81c50de0a51954c64444b849be4768c8116cffb
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -26,8 +26,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.0.7
-ENV COMMIT=75b7172cf77eb4fd65fe1a6924f75066fb09fcd1
+ENV VERSION=v1.0.8
+ENV COMMIT=d72e438c06e040e213b5decf5f29543c86cbad0f
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.21 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.9.2
-ENV COMMIT=224c5fd65cb4e8204258291e74263c1e70466176
+ENV VERSION=v1.9.3
+ENV COMMIT=e81c50de0a51954c64444b849be4768c8116cffb
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

- This PR resolves #LISK-1095.
- This PR resolves #LISK-1145.
- This PR resolves #LISK-1152.

### How was it solved?

- [x] OP Stack version was bumped to [v1.9.3](https://github.com/ethereum-optimism/optimism/releases/tag/v1.9.3)
- [x] GitHub PR workflow was modified to use `linux-amd64` and `linux-arm64` architectures appropriately
- [x] Reth version was bumped to [v1.0.8](https://github.com/paradigmxyz/reth/releases/tag/v1.0.8)

### How was it tested?

- `CLIENT=reth docker compose up --build --detach`
- `docker compose up --build --detach`
