### PR TITLE
Update snapshot resolution process

### DIFF
--- a/.env.mainnet
+++ b/.env.mainnet
@@ -3,7 +3,9 @@ SEQUENCER_HTTP=https://rpc.api.lisk.com
 RETH_CHAIN=lisk
 
 APPLY_SNAPSHOT=${APPLY_SNAPSHOT:-false}
-SNAPSHOT_URL=http://snapshots.lisk.com/mainnet/geth-snapshot
+SNAPSHOT_TYPE=${SNAPSHOT_TYPE:-export}
+SNAPSHOT_NETWORK=mainnet
+SNAPSHOT_URL=${SNAPSHOT_URL}
 
 # [optional] used to enable geth stats:
 # OP_GETH_ETH_STATS=nodename:secret@host:port

--- a/.env.mainnet
+++ b/.env.mainnet
@@ -5,7 +5,7 @@ RETH_CHAIN=lisk
 APPLY_SNAPSHOT=${APPLY_SNAPSHOT:-false}
 SNAPSHOT_TYPE=${SNAPSHOT_TYPE:-export}
 SNAPSHOT_NETWORK=mainnet
-SNAPSHOT_URL=${SNAPSHOT_URL}
+SNAPSHOT_URL=${SNAPSHOT_URL:-}
 
 # [optional] used to enable geth stats:
 # OP_GETH_ETH_STATS=nodename:secret@host:port

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -3,7 +3,9 @@ SEQUENCER_HTTP=https://rpc.sepolia-api.lisk.com
 RETH_CHAIN=lisk-sepolia
 
 APPLY_SNAPSHOT=${APPLY_SNAPSHOT:-false}
-SNAPSHOT_URL=http://snapshots.lisk.com/sepolia/geth-snapshot
+SNAPSHOT_TYPE=${SNAPSHOT_TYPE:-export}
+SNAPSHOT_NETWORK=sepolia
+SNAPSHOT_URL=${SNAPSHOT_URL}
 
 # [optional] used to enable geth stats:
 # OP_GETH_ETH_STATS=nodename:secret@host:port

--- a/.env.sepolia
+++ b/.env.sepolia
@@ -5,7 +5,7 @@ RETH_CHAIN=lisk-sepolia
 APPLY_SNAPSHOT=${APPLY_SNAPSHOT:-false}
 SNAPSHOT_TYPE=${SNAPSHOT_TYPE:-export}
 SNAPSHOT_NETWORK=sepolia
-SNAPSHOT_URL=${SNAPSHOT_URL}
+SNAPSHOT_URL=${SNAPSHOT_URL:-}
 
 # [optional] used to enable geth stats:
 # OP_GETH_ETH_STATS=nodename:secret@host:port

--- a/README.md
+++ b/README.md
@@ -224,20 +224,34 @@ Refer to the `op-node` configuration [documentation](https://docs.optimism.io/bu
 
 ## Snapshots
 
-> **Note**: Currently, snapshots are only available for the `op-geth` client and are **NOT** regularly updated. We are currently working on improving this.
+> **Note**:
+> - Snapshots are only available for the `op-geth` client and are from an archival node. They are of two types:
+>   - `export`: small download size, slow to restore from, data is verified during restore
+>   - `datadir`: large download size, fast to restore from, no data verification during restore
 
 ### Docker
 
-To enable auto-snapshot download and application, please set the `APPLY_SNAPSHOT` environment variable to `true` when starting the node.
+To enable auto-snapshot download and application, please set the `APPLY_SNAPSHOT` environment variable to `true`, when starting the node.
 ```sh
 APPLY_SNAPSHOT=true docker compose up --build --detach
+```
+
+To choose the snapshot type, please set the `SNAPSHOT_TYPE` flag to either `export` (default) or `datadir`, when starting the node.
+```sh
+APPLY_SNAPSHOT=true SNAPSHOT_TYPE=export docker compose up --build --detach
+```
+
+You can also download and apply a snapshot from a custom URL by setting the `SNAPSHOT_URL` environment variable.
+Please make sure the snapshot file ends with `*.tar.gz`.
+```sh
+APPLY_SNAPSHOT=true SNAPSHOT_URL=<custom-snapshot-url> docker compose up --build --detach
 ```
 
 ### Source
 
 Please follow the steps below:
 
-- Download the snapshot and the corresponding checksum from. The latest snapshot is always named `geth-snapshot`:
+- Download the snapshot and the corresponding checksum from. The latest snapshot name is always listed in the `latest-<export|datadir>` file:
   - Sepolia: https://snapshots.lisk.com/sepolia
   - Mainnet: https://snapshots.lisk.com/mainnet
 
@@ -246,10 +260,16 @@ Please follow the steps below:
   sha256sum -c <checksum-file-name>
   ```
 
-- Import the snapshot
-  ```sh
-  ./build/bin/geth import --datadir=$GETH_DATA_DIR <path-to-snapshot>
-  ```
+- Import the snapshot:
+  - `export`:
+    ```sh
+    tar -xf <path-to-downloaded-export-snapshot-tarball>
+    ./build/bin/geth import --datadir=$GETH_DATA_DIR <path-to-extracted-export-snapshot>
+    ```
+  - `datadir`:
+    ```sh
+    tar --directory $GETH_DATA_DIR -xf <path-to-datadir-snapshot>
+    ```
 
 ## Syncing
 

--- a/geth/download-apply-snapshot.sh
+++ b/geth/download-apply-snapshot.sh
@@ -13,14 +13,17 @@ if [[ "$APPLY_SNAPSHOT" == "FALSE" ]]; then
   exit 0
 fi
 
-if [[ "${SNAPSHOT_URL-x}" == x || -z $SNAPSHOT_URL ]]; then
-  echo "APPLY_SNAPSHOT enabled but SNAPSHOT_URL is undefined"
+if [[ "${GETH_DATA_DIR-x}" == x ]]; then
+  echo "GETH_DATA_DIR is undefined"
   exit 1
 fi
 
-if [[ "${GETH_DATA_DIR-x}" == x ]]; then
-  echo "GETH_DATA_DIR is undefined"
-  exit 2
+if [[ "${SNAPSHOT_URL-x}" == x || -z $SNAPSHOT_URL ]]; then
+  readonly SNAPSHOT_URL_BASE="https://snapshots.lisk.com/$SNAPSHOT_NETWORK"
+  readonly LATEST_SNAPSHOT_NAME=$(curl --silent --location $SNAPSHOT_URL_BASE/latest-$SNAPSHOT_TYPE)
+  readonly SNAPSHOT_URL="$SNAPSHOT_URL_BASE/$LATEST_SNAPSHOT_NAME"
+
+  echo "SNAPSHOT_URL not specified; automatically resolved to $SNAPSHOT_URL"
 fi
 
 readonly SNAPSHOT_DIR=./snapshot


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1192

### How was it solved?

- [x] Added the `latest-<export|datadir>` files to https://snapshots.lisk.com/<mainnet|sepolia>
- [x] Updated `geth/download-apply-snapshot.sh` script
- [x] Updated defaults in `.env.*` files
- [x] Updated README with the details

### How was it tested?

- `APPLY_SNAPSHOT=true SNAPSHOT_TYPE=export docker compose up --build --detach`
- `APPLY_SNAPSHOT=true SNAPSHOT_TYPE=datadir docker compose up --build --detach`
- `APPLY_SNAPSHOT=true SNAPSHOT_URL=http://snapshots.lisk.com/mainnet/geth-export-2024-09-03T01-06-02.tar.gz docker compose up --build --detach`
