### PR TITLE
Update Reth client to v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ Navigate to your `op-geth` directory and start service by running the command:
     --rollup.sequencerhttp=SEQUENCER_HTTP \
     --rollup.halt=major \
     --port=30303 \
-    --rollup.disabletxpoolgossip=true \
-    --engine.experimental
+    --rollup.disabletxpoolgossip=true
 ```
 
 Refer to the `op-geth` configuration [documentation](https://docs.optimism.io/builders/node-operators/management/configuration#op-geth) for detailed information about available options.

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -22,8 +22,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.1.0
-ENV COMMIT=1ba631ba9581973e7c6cadeea92cfe1802aceb4a
+ENV VERSION=v1.1.1
+ENV COMMIT=15c230bac20e2b1b3532c8b0d470e815fbc0cc22
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/reth-entrypoint
+++ b/reth/reth-entrypoint
@@ -44,5 +44,4 @@ exec ./op-reth node \
     --disable-discovery \
     --port="$P2P_PORT" \
     --rollup.sequencer-http=$SEQUENCER_HTTP \
-    --rollup.disable-tx-pool-gossip \
-    --engine.experimental
+    --rollup.disable-tx-pool-gossip


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1248.

### How was it solved?

- [x] Update op-reth client to [v1.1.1](https://github.com/paradigmxyz/reth/releases/tag/v1.1.1).
- [x] Remove `--engine.experimental` flag for op-reth client as experimental engine is default now and the `--engine.experimental` flag is deprecated.
- [x] Update README to reflect the update in the op-reth start command when running with the CLI.

### How was it tested?

- `CLIENT=reth docker compose up --build --detach`
