### PR TITLE
Unable to download Lisk Sepolia datadir snapshots

### DIFF
--- a/geth/geth-entrypoint
+++ b/geth/geth-entrypoint
@@ -28,7 +28,7 @@ fi
 mkdir -p $GETH_DATA_DIR
 
 # Download and apply snapshot, when configured
-(. download-apply-snapshot.sh)
+(. download-apply-snapshot.sh) || echo "Unable to download and apply snapshot. Skipping snapshot application..."
 
 # Set the start flags
 echo "$OP_NODE_L2_ENGINE_AUTH_RAW" > "$OP_NODE_L2_ENGINE_AUTH"


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1290

### How was it solved?

- [x] Snapshot upload script updated to use alternate href for necessary files on `https://snapshots.lisk.com/{network}/index.html`
- [x] Update the `geth/download-apply-snapshot.sh` script to use alternate URL when necessary

### How was it tested?

Run Lisk node against Lisk Sepolia with:
```
APPLY_SNAPSHOT=true SNAPSHOT_TYPE=datadir docker compose up --build --detach
```
