### PR TITLE
Bump op-node and op-geth client versions

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.22 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.10.0
-ENV COMMIT=910c9ade39c0bcdff5f2badd94efbe016a428e73
+ENV VERSION=v1.10.1
+ENV COMMIT=b707cd8ea9cb7f7b3571131584f81c79db02c336
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -17,8 +17,8 @@ FROM golang:1.22 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101411.2
-ENV COMMIT=3dd9b0274bae3d3d2c80ef517563a360108e8cf6
+ENV VERSION=v1.101411.3
+ENV COMMIT=717daa16e204bf9c7e50994284c1d09970d8ee73
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:1.22 AS op
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.10.0
-ENV COMMIT=910c9ade39c0bcdff5f2badd94efbe016a428e73
+ENV VERSION=v1.10.1
+ENV COMMIT=b707cd8ea9cb7f7b3571131584f81c79db02c336
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1412

### How was it solved?

Bump client versions as specified

### How was it tested?

`docker compose up --build --detach`
`CLIENT=reth RETH_BUILD_PROFILE=maxperf docker compose up --build --detach`
