### PR TITLE
Publish docker images to ECR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,9 +6,14 @@ on:
       - main
       - LISK-1402-Publish-docker-images-to-ECR
 
+env:
+  DOCKER_BUILD_PLATFORMS: linux/amd64
+  RETH_FEATURES: jemalloc,asm-keccak,optimism
+  RETH_BUILD_PROFILE: release
+
 jobs:
-  docker:
-    name: Build and push docker image
+  docker_prep:
+    name: Pre-prep for docker image build
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name }}
 
@@ -44,12 +49,12 @@ jobs:
         uses: docker/build-push-action@v6
         id: docker-build-mainnet
         with:
-          context: ./
-          file: ./reth/Dockerfile
+          context: .
+          file: reth/Dockerfile
           build-args: |
-            FEATURES=jemalloc,asm-keccak,optimism
-            RETH_BUILD_PROFILE=maxperf
-          platforms: linux/amd64
+            FEATURES=${{ env.RETH_FEATURES }}
+            RETH_BUILD_PROFILE=${{ env.RETH_BUILD_PROFILE }}
+          platforms: ${{ env.DOCKER_BUILD_PLATFORMS }}
           push: true
           tags: |
             ${{ steps.docker-image-mainnet.outputs.image }}:latest
@@ -63,12 +68,12 @@ jobs:
         uses: docker/build-push-action@v6
         id: docker-build-sepolia
         with:
-          context: ./
-          file: ./reth/Dockerfile
+          context: .
+          file: reth/Dockerfile
           build-args: |
-            FEATURES=jemalloc,asm-keccak,optimism
-            RETH_BUILD_PROFILE=maxperf
-          platforms: linux/amd64
+            FEATURES=${{ env.RETH_FEATURES }}
+            RETH_BUILD_PROFILE=${{ env.RETH_BUILD_PROFILE }}
+          platforms: ${{ env.DOCKER_BUILD_PLATFORMS }}
           push: true
           tags: |
             ${{ steps.docker-image-sepolia.outputs.image }}:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,12 +4,11 @@ on:
   push:
     branches:
       - main
-      - LISK-1402-Publish-docker-images-to-ECR
 
 env:
   DOCKER_BUILD_PLATFORMS: linux/amd64
   RETH_FEATURES: jemalloc,asm-keccak,optimism
-  RETH_BUILD_PROFILE: release
+  RETH_BUILD_PROFILE: maxperf
 
 jobs:
   docker_prep:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,19 +4,17 @@ on:
   push:
     branches:
       - main
-      - LISK-1402-Publish-docker-images-to-ECR
 
 env:
   DOCKER_BUILD_PLATFORMS: linux/amd64
   RETH_FEATURES: jemalloc,asm-keccak,optimism
-  RETH_BUILD_PROFILE: release
+  RETH_BUILD_PROFILE: maxperf
 
 jobs:
   docker_prep:
-    name: Pre-prep for docker image build
+    name: Build and push docker image
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,50 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  docker:
+    name: Build and push docker image
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@0e613a0980cbf65ed5b322eb7a1e075d28913a83
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@62f4f872db3836360b72999f4b87f1ff13310f3a
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker image
+        id: docker-image
+        run: |
+          echo "image=${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}" >> $GITHUB_OUTPUT
+
+      - name: Build and push the image
+        uses: docker/build-push-action@v6
+        id: docker-build
+        with:
+          context: ./
+          file: ./reth/Dockerfile
+          build-args: |
+            FEATURES=jemalloc,asm-keccak,optimism
+            RETH_BUILD_PROFILE=maxperf
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.docker-image.outputs.image }}:latest
+            ${{ steps.docker-image.outputs.image }}:${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - LISK-1402-Publish-docker-images-to-ECR
 
 jobs:
   docker:
@@ -29,14 +30,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Docker image
-        id: docker-image
+      - name: Docker image - Mainnet
+        id: docker-image-mainnet
         run: |
           echo "image=${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}" >> $GITHUB_OUTPUT
 
-      - name: Build and push the image
+      - name: Docker image - Sepolia
+        id: docker-image-sepolia
+        run: |
+          echo "image=${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY_SEPOLIA }}" >> $GITHUB_OUTPUT
+
+      - name: Build and push image for Lisk Mainnet
         uses: docker/build-push-action@v6
-        id: docker-build
+        id: docker-build-mainnet
         with:
           context: ./
           file: ./reth/Dockerfile
@@ -46,5 +52,24 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ${{ steps.docker-image.outputs.image }}:latest
-            ${{ steps.docker-image.outputs.image }}:${{ github.sha }}
+            ${{ steps.docker-image-mainnet.outputs.image }}:latest
+            ${{ steps.docker-image-mainnet.outputs.image }}:${{ github.sha }}
+
+      - name: Apply Lisk Sepolia hotfix
+        id: apply-sepolia-hotfix
+        run: git apply ./dockerfile-lisk-sepolia.patch
+
+      - name: Build and push image for Lisk Sepolia
+        uses: docker/build-push-action@v6
+        id: docker-build-sepolia
+        with:
+          context: ./
+          file: ./reth/Dockerfile
+          build-args: |
+            FEATURES=jemalloc,asm-keccak,optimism
+            RETH_BUILD_PROFILE=maxperf
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ steps.docker-image-sepolia.outputs.image }}:latest
+            ${{ steps.docker-image-sepolia.outputs.image }}:${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,17 +4,21 @@ on:
   push:
     branches:
       - main
+      - LISK-1402-Publish-docker-images-to-ECR
 
 env:
   DOCKER_BUILD_PLATFORMS: linux/amd64
   RETH_FEATURES: jemalloc,asm-keccak,optimism
-  RETH_BUILD_PROFILE: maxperf
+  RETH_BUILD_PROFILE: release
 
 jobs:
   docker_prep:
     name: Build and push docker image
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name }}
+    strategy:
+      matrix:
+        network: [mainnet, sepolia]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,38 +37,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Docker image - Mainnet
-        id: docker-image-mainnet
+      - name: Docker image
+        id: docker-image
         run: |
-          echo "image=${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}" >> $GITHUB_OUTPUT
-
-      - name: Docker image - Sepolia
-        id: docker-image-sepolia
-        run: |
-          echo "image=${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY_SEPOLIA }}" >> $GITHUB_OUTPUT
-
-      - name: Build and push image for Lisk Mainnet
-        uses: docker/build-push-action@v6
-        id: docker-build-mainnet
-        with:
-          context: .
-          file: reth/Dockerfile
-          build-args: |
-            FEATURES=${{ env.RETH_FEATURES }}
-            RETH_BUILD_PROFILE=${{ env.RETH_BUILD_PROFILE }}
-          platforms: ${{ env.DOCKER_BUILD_PLATFORMS }}
-          push: true
-          tags: |
-            ${{ steps.docker-image-mainnet.outputs.image }}:latest
-            ${{ steps.docker-image-mainnet.outputs.image }}:${{ github.sha }}
+          if [ "${{ matrix.network }}" = "mainnet" ];
+          then
+            echo "image=${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}" >> $GITHUB_OUTPUT
+          else
+            echo "image=${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY_SEPOLIA }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Apply Lisk Sepolia hotfix
         id: apply-sepolia-hotfix
+        if: ${{ matrix.network == 'sepolia' }}
         run: git apply ./dockerfile-lisk-sepolia.patch
 
-      - name: Build and push image for Lisk Sepolia
+      - name: Build and push image
         uses: docker/build-push-action@v6
-        id: docker-build-sepolia
+        id: docker-build
         with:
           context: .
           file: reth/Dockerfile
@@ -74,5 +64,5 @@ jobs:
           platforms: ${{ env.DOCKER_BUILD_PLATFORMS }}
           push: true
           tags: |
-            ${{ steps.docker-image-sepolia.outputs.image }}:latest
-            ${{ steps.docker-image-sepolia.outputs.image }}:${{ github.sha }}
+            ${{ steps.docker-image.outputs.image }}:latest
+            ${{ steps.docker-image.outputs.image }}:${{ github.sha }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   linux_amd64:
+    name: Verify image build on linux/amd64 platform
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -18,8 +19,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build the Docker image
         uses: docker/build-push-action@v6
         with:
@@ -29,7 +32,9 @@ jobs:
           build-args: |
             FEATURES=${{ matrix.features }}
           platforms: linux/amd64
+
   linux_arm64:
+    name: Verify image build on linux/arm64 platform
     runs-on: linux-arm64
     strategy:
       matrix:
@@ -43,8 +48,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Build the Docker image
         uses: docker/build-push-action@v6
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         include:
           - file: geth/Dockerfile
-            features: 
+            features:
           - file: reth/Dockerfile
             features: jemalloc,asm-keccak,optimism
     steps:
@@ -35,7 +35,7 @@ jobs:
       matrix:
         include:
           - file: geth/Dockerfile
-            features: 
+            features:
           - file: reth/Dockerfile
             features: jemalloc,optimism
     steps:


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1402

### How was it solved?

- [x] Created new ECR private repositories
- [x] Added necessary secrets to the repo
- [x] Added `.github/workflows/docker.yml`

### How was it tested?

- With push on current branch (GHA [run](https://github.com/LiskHQ/lisk-node/actions/runs/12237790997/job/34134343676))
- Validated both the ECR repos from console. Both mainnet and sepolia repositories have uploaded docker images with different digests, as expected
