### PR TITLE
Bump reth client to v1.1.4

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -22,8 +22,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.1.2
-ENV COMMIT=496bf0bf715f0a1fafc198f8d72ccd71913d1a40
+ENV VERSION=v1.1.4
+ENV COMMIT=15fac0873e91ea29ab2e605bfba17bedcd7a6084
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1432

### How was it solved?

- [x] Bump reth client to v1.1.4

### How was it tested?

Run node against both Lisk mainnet and Lisk sepolia network.

```
(Additionally, only for Lisk sepolia) git apply dockerfile-lisk-sepolia.patch 
CLIENT=reth docker compose up --build --detach
```
