### PR TITLE
Bump reth client to v1.1.5

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.1.4
-ENV COMMIT=15fac0873e91ea29ab2e605bfba17bedcd7a6084
+ENV VERSION=v1.1.5
+ENV COMMIT=3212af2d85a54eb207661361ac9fe1d7de4b5b8e
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1498

### How was it solved?

- [x] Bump reth client to v1.1.5

### How was it tested?

Locally against both Lisk Sepolia and Mainnet with binaries built in maxperf/release profiles.
```
git apply dockerfile-lisk-sepolia.patch (Only for Lisk Sepolia)
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
```