### PR TITLE
Bump op-geth to v1.101411.8

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -18,8 +18,8 @@ FROM golang:1.22 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101411.7
-ENV COMMIT=b79c44a850e7a86b74e50bcdaca18690ba01783d
+ENV VERSION=v1.101411.8
+ENV COMMIT=374d61f9038d87216496477c9fab0db94ea27e86
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -18,8 +18,8 @@ FROM golang:1.22 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101411.6
-ENV COMMIT=50b3422b9ac682a8fa503c4f409339a9bff69717
+ENV VERSION=v1.101411.7
+ENV COMMIT=b79c44a850e7a86b74e50bcdaca18690ba01783d
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1699

### How was it solved?

- ~~Bump op-geth to [v1.101411.7](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101411.7)~~
- Bump op-geth to [v1.101411.8](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101411.8)

### How was it tested?

Tested with Lisk Mainnet