### PR TITLE
Bump op node to v1.11.1

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.11.0
-ENV COMMIT=70fa4491f45b3d5d493394da2a154e3f22b61a5a
+ENV VERSION=v1.11.1
+ENV COMMIT=443e931f242e1595896d6598b02068dc822e1232
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.11.0
-ENV COMMIT=70fa4491f45b3d5d493394da2a154e3f22b61a5a
+ENV VERSION=v1.11.1
+ENV COMMIT=443e931f242e1595896d6598b02068dc822e1232
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK 1740

### How was it solved?

Bump op node to v1.11.1

### How was it tested?

`docker compose up --build --detach`
`CLIENT=reth RETH_BUILD_PROFILE=maxperf docker compose up --build --detach`
