### PR TITLE
Bump reth client to v1.2.1

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.2.0
-ENV COMMIT=1e965caf5fa176f244a31c0d2662ba1b590938db
+ENV VERSION=v1.2.1
+ENV COMMIT=baf5dcc0d51f44a81f5f6a42c093c05511d118b2
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK 1817

### How was it solved?

Bump reth client to v1.2.1

### How was it tested?

CLIENT=reth RETH_BUILD_PROFILE=maxperf docker compose up --build --detach
