### PR TITLE
Bump op node to v1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ Refer to the `reth` configuration [documentation](https://reth.rs/cli/reth/node.
 > <br>Official Lisk Sequencer HTTP RPC endpoints:
 > - **Lisk Sepolia**: https://rpc.sepolia-api.lisk.com
 > - **Lisk Mainnet**: https://rpc.api.lisk.com
+>
+> ⚠️ Please consider using a private endpoint to connect to the sequencer when running your own node if you encounter rate limit issues. More information is available here: [Using RPC Nodes](https://docs.gelato.network/developer-services/rpc-nodes/using-rpc-nodes)
+> 
 
 #### Run op-node
 

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.11.1
-ENV COMMIT=443e931f242e1595896d6598b02068dc822e1232
+ENV VERSION=v1.12.0
+ENV COMMIT=ab06b2e81b4525f6f1e45e928989b21ab904e26f
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -18,8 +18,8 @@ FROM golang:1.22 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101500.0
-ENV COMMIT=9111c8f18ce514916105252f4530782e2ac2b598
+ENV VERSION=v1.101503.0 
+ENV COMMIT=27ec85a855372aa0319b08e2eaa53215f4584636
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.11.1
-ENV COMMIT=443e931f242e1595896d6598b02068dc822e1232
+ENV VERSION=v1.12.0
+ENV COMMIT=ab06b2e81b4525f6f1e45e928989b21ab904e26f
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1853

### How was it solved?

Bump op node to v1.12.0

### How was it tested?

`docker compose up --build --detach`
`CLIENT=reth RETH_BUILD_PROFILE=maxperf docker compose up --build --detach`
