### PR TITLE
Update reth client to v1.3.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   DOCKER_BUILD_PLATFORMS: linux/amd64
-  RETH_FEATURES: jemalloc,asm-keccak,optimism
+  RETH_FEATURES: jemalloc,asm-keccak
   RETH_BUILD_PROFILE: maxperf
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
           - file: geth/Dockerfile
             features:
           - file: reth/Dockerfile
-            features: jemalloc,asm-keccak,optimism
+            features: jemalloc,asm-keccak
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
           - file: geth/Dockerfile
             features:
           - file: reth/Dockerfile
-            features: jemalloc,optimism
+            features: jemalloc
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/dockerfile-lisk-sepolia.patch
+++ b/dockerfile-lisk-sepolia.patch
@@ -31,4 +31,4 @@ index 0144140..bbb833f 100644
 +    cd op-node && \
      make VERSION=$VERSION op-node
  
- FROM rust:1.82 AS reth
+ FROM rust:1.85 AS reth

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -13,9 +13,9 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
 RUN cd op-node && \
     make VERSION=$VERSION op-node
 
-FROM rust:1.82 AS reth
+FROM rust:1.85 AS reth
 
-ARG FEATURES=jemalloc,asm-keccak,optimism
+ARG FEATURES=jemalloc,asm-keccak
 ARG PROFILE=maxperf
 
 WORKDIR /app
@@ -23,8 +23,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.2.2
-ENV COMMIT=2f4c509b3d01960f96abf2f9314b7d63db36977b
+ENV VERSION=v1.3.0
+ENV COMMIT=a38c991c363d241894867a89324b8670be2f6a44
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1860.

### How was it solved?

- [x] Bump reth client to [v1.3.0](https://github.com/paradigmxyz/reth/releases/tag/v1.3.0)
- [x] [optimism feature was removed](https://github.com/paradigmxyz/reth/pull/14545)

### How was it tested?

Locally against both Lisk Sepolia and Mainnet.

```
git apply dockerfile-lisk-sepolia.patch (Only for Lisk Sepolia)
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
```