### PR TITLE
Update clients to the latest versions

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.12.0
-ENV COMMIT=ab06b2e81b4525f6f1e45e928989b21ab904e26f
+ENV VERSION=v1.12.1
+ENV COMMIT=d3b8eadd80457c74d9c4251948ac11e8d14a9c9c
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -18,8 +18,8 @@ FROM golang:1.22 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101503.0 
-ENV COMMIT=27ec85a855372aa0319b08e2eaa53215f4584636
+ENV VERSION=v1.101503.1 
+ENV COMMIT=fbc739c3e40aba2f59181912470fa0b1bd7a2805
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.12.0
-ENV COMMIT=ab06b2e81b4525f6f1e45e928989b21ab904e26f
+ENV VERSION=v1.12.1
+ENV COMMIT=d3b8eadd80457c74d9c4251948ac11e8d14a9c9c
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.3.0
-ENV COMMIT=a38c991c363d241894867a89324b8670be2f6a44
+ENV VERSION=v1.3.1
+ENV COMMIT=8142c6c327e6462f2f6a009036bc5c585afc52a0
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1877.

### How was it solved?

- [x] Bump op-reth client to [v1.3.1](https://github.com/paradigmxyz/reth/releases/tag/v1.3.1)
- [x] Bump op-node client to [v1.12.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.12.1)
- [x] Bump op-geth client to [v1.101503.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101503.1)

### How was it tested?

Locally against both Lisk Sepolia and Mainnet.

```
git apply dockerfile-lisk-sepolia.patch (Only for Lisk Sepolia)
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
docker compose up --build --detach
```