### PR TITLE
Update op-reth to v1.3.2

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.3.1
-ENV COMMIT=8142c6c327e6462f2f6a009036bc5c585afc52a0
+ENV VERSION=v1.3.2
+ENV COMMIT=802a1c7bd6fc3b1c5e051048ca7f96fedef838d3
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1884.

### How was it solved?

- [x] Bump reth client to [v1.3.2](https://github.com/paradigmxyz/reth/releases/tag/v1.3.2)

### How was it tested?

Locally against both Lisk Sepolia and Mainnet.

```
git apply dockerfile-lisk-sepolia.patch (Only for Lisk Sepolia)
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
```