### PR TITLE
Add override flag for Pectra upgrade for Sepolia network

### DIFF
--- a/op-node-entrypoint
+++ b/op-node-entrypoint
@@ -7,7 +7,11 @@ echoBanner() {
 	echo -e "------------------------------------------------------------------------------------------------------------\n"
 }
 
-[ "$OP_NODE_NETWORK" = lisk-sepolia ] && ADDITIONAL_ARGS="--override.holocene=1732633200" || ADDITIONAL_ARGS=""
+if [ "$OP_NODE_NETWORK" = lisk-sepolia ]; then
+    ADDITIONAL_ARGS="--override.holocene=1732633200 --override.pectrablobschedule=1742486400"
+else
+    ADDITIONAL_ARGS=""
+fi
 
 get_public_ip() {
   # Define a list of HTTP-based providers


### PR DESCRIPTION
### What was the problem?

This PR resolves #1887.

### How was it solved?

New override flag was added for Pectra Blob Schedule for Sepolia network.

### How was it tested?

Locally against Lisk Sepolia.

```
git apply dockerfile-lisk-sepolia.patch
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
docker compose up --build --detach
```
