### PR TITLE
Bump op node to v1.12.2

### DIFF
--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.12.1
-ENV COMMIT=d3b8eadd80457c74d9c4251948ac11e8d14a9c9c
+ENV VERSION=v1.12.2
+ENV COMMIT=6638905c0cbe190b6c3fdf99dfc8f67e60cd657c
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.12.1
-ENV COMMIT=d3b8eadd80457c74d9c4251948ac11e8d14a9c9c
+ENV VERSION=v1.12.2
+ENV COMMIT=6638905c0cbe190b6c3fdf99dfc8f67e60cd657c
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1895

### How was it solved?

Bump op node to v1.12.2

### How was it tested?

```
git apply dockerfile-lisk-sepolia.patch (Only for Lisk Sepolia)
docker compose up --build --detach
CLIENT=reth RETH_BUILD_PROFILE=release docker compose up --build --detach
```