### PR TITLE
Bump reth client to v1.3.4

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.3.2
-ENV COMMIT=802a1c7bd6fc3b1c5e051048ca7f96fedef838d3
+ENV VERSION=v1.3.3
+ENV COMMIT=b0d9a6b14bc1c35549979516f4fdd38feed81cfa
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.3.3
-ENV COMMIT=b0d9a6b14bc1c35549979516f4fdd38feed81cfa
+ENV VERSION=v1.3.4
+ENV COMMIT=90c514ca818a36eb8cd36866156c26a4221e9c4a
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1897

### How was it solved?

Bump reth client to v1.3.4

### How was it tested?

```
git apply dockerfile-lisk-sepolia.patch (Only for Lisk Sepolia)
CLIENT=reth RETH_BUILD_PROFILE=release docker compose up --build --detach
```
