### PR TITLE
Bump op node to v1.13.0 and op geth to v1.101503.2 and update configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,6 @@ INFO [06-26|13:31:20.389] Advancing bq origin                      origin=17171d
 
 For more information refer to the OP [documentation](https://docs.optimism.io/builders/node-operators/tutorials/mainnet#full-sync).
 
-> **Note**:
-> - In case you had skipped the `op-geth` [initialization step](#initialize-op-geth) above, you can start the node with the `--network=OP_NODE_NETWORK` flag.
-> - When specifying the `--network` flag, kindly make sure to remove the `--rollup.config` flag.
-
 Refer to the `op-node` configuration [documentation](https://docs.optimism.io/builders/node-operators/management/configuration#op-node) for detailed information about available options.
 
 > **Note**:

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.12.2
-ENV COMMIT=6638905c0cbe190b6c3fdf99dfc8f67e60cd657c
+ENV VERSION=v1.13.0
+ENV COMMIT=5f003211aed7469eed7df666291a62c025d1c46c
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -18,8 +18,8 @@ FROM golang:1.22 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101503.1 
-ENV COMMIT=fbc739c3e40aba2f59181912470fa0b1bd7a2805
+ENV VERSION=v1.101503.2 
+ENV COMMIT=37be9e05e9d6843619c9bbaabc96abc0ce653f55
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/geth/geth-entrypoint
+++ b/geth/geth-entrypoint
@@ -15,9 +15,9 @@ AUTHRPC_PORT="${AUTHRPC_PORT:-8551}"
 METRICS_PORT="${METRICS_PORT:-6060}"
 HOST_IP="" # put your external IP address here and open port 30303 to improve peer connectivity
 P2P_PORT="${P2P_PORT:-30303}"
+ADDITIONAL_ARGS=""
 OP_GETH_GCMODE="${OP_GETH_GCMODE:-full}"
 OP_GETH_SYNCMODE="${OP_GETH_SYNCMODE:-full}"
-[ "$OP_NODE_NETWORK" = lisk-sepolia ] && ADDITIONAL_ARGS="--override.holocene=1732633200" || ADDITIONAL_ARGS=""
 
 if [[ -z "$OP_NODE_NETWORK" ]]; then
     echo "expected OP_NODE_NETWORK to be set" 1>&2

--- a/op-node-entrypoint
+++ b/op-node-entrypoint
@@ -7,11 +7,7 @@ echoBanner() {
 	echo -e "------------------------------------------------------------------------------------------------------------\n"
 }
 
-if [ "$OP_NODE_NETWORK" = lisk-sepolia ]; then
-    ADDITIONAL_ARGS="--override.holocene=1732633200 --override.pectrablobschedule=1742486400"
-else
-    ADDITIONAL_ARGS=""
-fi
+ADDITIONAL_ARGS=""
 
 get_public_ip() {
   # Define a list of HTTP-based providers

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.12.2
-ENV COMMIT=6638905c0cbe190b6c3fdf99dfc8f67e60cd657c
+ENV VERSION=v1.13.0
+ENV COMMIT=5f003211aed7469eed7df666291a62c025d1c46c
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1942

### How was it solved?

- Bump op node to v1.13.0 and op geth to v1.101503.2
- Remove unnecessary configs as lisk sepolia is included in superchain registry
- Update readme to remove obsolete content

### How was it tested?
```
git apply dockerfile-lisk-sepolia.patch (Only for Lisk Sepolia)
docker compose up --build --detach
```