### PR TITLE
Bump reth client to v1.3.10

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.3.9
-ENV COMMIT=00e5b6e01e3cf4c86cb3625f7aff52b81960d724
+ENV VERSION=v1.3.10
+ENV COMMIT=b36fc954d26258ac727b5cc13b771524411e1001
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #[LISK-1984](https://onchaincollective.atlassian.net/browse/LISK-1984)

### How was it solved?

Bump reth client to v1.3.10

### How was it tested?

Locally tested against for both:

- [x] Mainnet
```
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
```
- [x] Sepolia
```
git apply dockerfile-lisk-sepolia.patch
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
```

[LISK-1984]: https://onchaincollective.atlassian.net/browse/LISK-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ