### PR TITLE
Bump reth client to v1.3.11

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.3.10
-ENV COMMIT=b36fc954d26258ac727b5cc13b771524411e1001
+ENV VERSION=v1.3.11
+ENV COMMIT=e0e85aa10b98fa92d32c3e820c7ed2cee0b02931
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-1985

### How was it solved?

- Bump reth client to v1.3.11

### How was it tested?

Tested against both Lisk Mainnet & Lisk Sepolia (Sepolia w/ op-node-lisk-sepolia.patch applied)
