### PR TITLE
Bump reth client to v1.3.12

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.3.11
-ENV COMMIT=e0e85aa10b98fa92d32c3e820c7ed2cee0b02931
+ENV VERSION=v1.3.12
+ENV COMMIT=6f8e7258f4733279080e4bd8345ce50538a40d6e
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #[LISK-1993](https://onchaincollective.atlassian.net/browse/LISK-1993)

### How was it solved?

- Bump reth client to v1.3.12

### How was it tested?

Locally tested against for both:

- [x] Mainnet
```
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
```
- [x] Sepolia
```
git apply dockerfile-lisk-sepolia.patch
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
```

[LISK-1993]: https://onchaincollective.atlassian.net/browse/LISK-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ