### PR TITLE
Bump op-node to v1.13.2 and op-geth to v1.101503.4

### DIFF
--- a/dockerfile-lisk-sepolia.patch
+++ b/dockerfile-lisk-sepolia.patch
@@ -1,8 +1,8 @@
 diff --git a/geth/Dockerfile b/geth/Dockerfile
-index 7316271..86e9a33 100644
+index 0bc9509..8a71f8e 100644
 --- a/geth/Dockerfile
 +++ b/geth/Dockerfile
-@@ -9,7 +9,11 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
+@@ -13,7 +13,11 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
      git switch -c branch-$VERSION && \
      bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
  
@@ -14,12 +14,12 @@ index 7316271..86e9a33 100644
 +    cd op-node && \
      make VERSION=$VERSION op-node
  
- FROM golang:1.22 AS geth
+ FROM golang:$GOLANG_VERSION AS geth
 diff --git a/reth/Dockerfile b/reth/Dockerfile
-index 0144140..bbb833f 100644
+index 12f758f..7422365 100644
 --- a/reth/Dockerfile
 +++ b/reth/Dockerfile
-@@ -9,7 +9,11 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
+@@ -14,7 +14,11 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
      git switch -c branch-$VERSION && \
      bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
  
@@ -31,4 +31,4 @@ index 0144140..bbb833f 100644
 +    cd op-node && \
      make VERSION=$VERSION op-node
  
- FROM rust:1.85 AS reth
+ FROM rust:$RUST_VERSION AS reth

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.22 AS op
+ARG GOLANG_VERSION=1.24
+ARG UBUNTU_VERSION=25.04
+
+FROM golang:$GOLANG_VERSION AS op
 
 WORKDIR /app
 
@@ -13,12 +16,12 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
 RUN cd op-node && \
     make VERSION=$VERSION op-node
 
-FROM golang:1.22 AS geth
+FROM golang:$GOLANG_VERSION AS geth
 
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101503.4 
+ENV VERSION=v1.101503.4
 ENV COMMIT=2b9abb39077cb88f6e8a513f09a5ea2c2569dfed
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
@@ -26,7 +29,7 @@ RUN git clone $REPO --branch $VERSION --single-branch . && \
 
 RUN go run build/ci.go install -static ./cmd/geth
 
-FROM ubuntu:22.04
+FROM ubuntu:$UBUNTU_VERSION
 
 RUN apt-get update && \
     apt-get install -y jq curl supervisor && \

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.13.0
-ENV COMMIT=5f003211aed7469eed7df666291a62c025d1c46c
+ENV VERSION=v1.13.2
+ENV COMMIT=c8b9f62736a7dad7e569719a84c406605f4472e6
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -18,8 +18,8 @@ FROM golang:1.22 AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101503.2 
-ENV COMMIT=37be9e05e9d6843619c9bbaabc96abc0ce653f55
+ENV VERSION=v1.101503.4 
+ENV COMMIT=2b9abb39077cb88f6e8a513f09a5ea2c2569dfed
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -1,4 +1,8 @@
-FROM golang:1.22 AS op
+ARG GOLANG_VERSION=1.24
+ARG RUST_VERSION=1.86
+ARG UBUNTU_VERSION=25.04
+
+FROM golang:$GOLANG_VERSION AS op
 
 WORKDIR /app
 
@@ -13,7 +17,7 @@ RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
 RUN cd op-node && \
     make VERSION=$VERSION op-node
 
-FROM rust:1.85 AS reth
+FROM rust:$RUST_VERSION AS reth
 
 ARG FEATURES=jemalloc,asm-keccak
 ARG PROFILE=maxperf
@@ -31,7 +35,7 @@ RUN git clone $REPO --branch $VERSION --single-branch . && \
 
 RUN RUSTFLAGS="-C target-cpu=native" cargo build --bin op-reth --locked --features $FEATURES --profile $PROFILE --manifest-path crates/optimism/bin/Cargo.toml
 
-FROM ubuntu:22.04
+FROM ubuntu:$UBUNTU_VERSION
 
 ARG PROFILE=maxperf
 

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -4,8 +4,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.13.0
-ENV COMMIT=5f003211aed7469eed7df666291a62c025d1c46c
+ENV VERSION=v1.13.2
+ENV COMMIT=c8b9f62736a7dad7e569719a84c406605f4472e6
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #[LISK-1995](https://onchaincollective.atlassian.net/browse/LISK-1995)

### How was it solved?

- Bump op-node to v1.13.2 and op-geth to v1.101503.4
- Add isthmusTime to mainnet genesis block 
- Update dockerfiles with the latest image versions

### How was it tested?

Locally tested against for both:

- [x] Mainnet
```
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
docker compose up --build --detach // geth client
```
- [x] Sepolia
```
git apply dockerfile-lisk-sepolia.patch
CLIENT=reth RETH_BUILD_PROFILE=<maxperf|release> docker compose up --build --detach
docker compose up --build --detach // geth client
```

[LISK-1995]: https://onchaincollective.atlassian.net/browse/LISK-1995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ