### PR TITLE
Bump reth client to v1.4.7

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -27,8 +27,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.4.3
-ENV COMMIT=fe3653ffe602d4e85ad213e8bd9f06e7b710c0c5
+ENV VERSION=v1.4.7
+ENV COMMIT=dc7cb6e6670b0da294a0e5010e02855f5aaf6b49
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2183

### How was it solved?

Bump reth client to v1.4.7

### How was it tested?

`CLIENT=reth docker compose up --build --detach` 
