### PR TITLE
Bump reth client to v1.4.8

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -27,8 +27,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.4.7
-ENV COMMIT=dc7cb6e6670b0da294a0e5010e02855f5aaf6b49
+ENV VERSION=v1.4.8
+ENV COMMIT=127595e23079de2c494048d0821ea1f1107eb624
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2186

### How was it solved?

Bump reth client to v1.4.8

### How was it tested?

`CLIENT=reth docker compose up --build --detach`
