### PR TITLE
bump reth to v1.5.1

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -27,8 +27,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.5.0
-ENV COMMIT=61e38f9af154fe91e776d8f5e449d20a1571e8cf
+ENV VERSION=v1.5.1
+ENV COMMIT=dbe7ee9c21392f360ff01f6307480f5d7dd73a3a
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2280
### How was it solved?

- Bump reth client to v1.5.1

### How was it tested?

- Lisk Sepolia
```sh
git apply dockerfile-lisk-sepolia.patch
COMPOSE_BAKE=true CLIENT=reth docker compose -p reth-sepolia up --build --detach
COMPOSE_BAKE=true CLIENT=reth docker compose -p reth-sepolia down
git apply -R dockerfile-lisk-sepolia.patch
```

- Lisk Mainnet
```sh
COMPOSE_BAKE=true CLIENT=reth docker compose -p reth-mainnet up --build --detach
COMPOSE_BAKE=true CLIENT=reth docker compose -p reth-mainnet down
```