### PR TITLE
Bump op-reth to v1.7.0, op-geth to v1.101602.0 and op-node to v1.13.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ cd lisk-node
 
 ### Source
 
+Please use the following client versions:
+
+- **op-node**: [v1.13.6](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.6)
+- **op-geth**: [v1.101602.0](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101602.0)
+- **op:reth**: [v1.7.0](https://github.com/paradigmxyz/reth/releases/tag/v1.7.0)
+
 #### Build
 
 - Before proceeding, please make sure to install the following dependency (**this information is missing in the OP documentations linked below**):

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.13.5
-ENV COMMIT=7a0ab04ea2db5421da689eb77a68e674e4ae9cfe
+ENV VERSION=v1.13.6
+ENV COMMIT=d6733fd693a685ee9dfbb74b9d64aeff851e1c11
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,8 +21,8 @@ FROM golang:$GOLANG_VERSION AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101511.1
-ENV COMMIT=c6e05723600e111af769abffd5299e3c72061016
+ENV VERSION=v1.101602.0
+ENV COMMIT=0c62eff49efa07af470d6822d6c377a5fec6da7b
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.13.5
-ENV COMMIT=7a0ab04ea2db5421da689eb77a68e674e4ae9cfe
+ENV VERSION=v1.13.6
+ENV COMMIT=d6733fd693a685ee9dfbb74b9d64aeff851e1c11
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -1,5 +1,5 @@
 ARG GOLANG_VERSION=1.24
-ARG RUST_VERSION=1.86
+ARG RUST_VERSION=1.88
 ARG UBUNTU_VERSION=25.04
 
 FROM golang:$GOLANG_VERSION AS op
@@ -27,8 +27,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.6.0
-ENV COMMIT=d8451e54e7267f9f1634118d6d279b2216f7e2bb
+ENV VERSION=v1.7.0
+ENV COMMIT=9d56da53ec0ad60e229456a0c70b338501d923a5
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2489

### How was it solved?

The following versions were updated:
- op-node: v1.13.6
- op-geth: v1.101602.0
- op-reth: v1.7.0

### How was it tested?

Spun up and ran local nodes against both Lisk Mainnet (w/o patch) and Sepolia (w/ patch) using both op-geth/op-reth.

```sh
git apply dockerfile-lisk-sepolia.patch
CLIENT=reth docker compose -p reth-sepolia up --build --detach
CLIENT=geth docker compose -p geth-sepolia up --build --detach

git apply -R dockerfile-lisk-sepolia.patch
CLIENT=reth docker compose -p reth-mainnet up --build --detach
CLIENT=geth docker compose -p geth-mainnet up --build --detach
```