### PR TITLE
Bump op-geth to v1.101602.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ cd lisk-node
 Please use the following client versions:
 
 - **op-node**: [v1.13.6](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.6)
-- **op-geth**: [v1.101602.0](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101602.0)
-- **op:reth**: [v1.7.0](https://github.com/paradigmxyz/reth/releases/tag/v1.7.0)
+- **op-geth**: [v1.101602.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101602.3)
+- **op-reth**: [v1.7.0](https://github.com/paradigmxyz/reth/releases/tag/v1.7.0)
 
 #### Build
 

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -21,8 +21,8 @@ FROM golang:$GOLANG_VERSION AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101602.0
-ENV COMMIT=0c62eff49efa07af470d6822d6c377a5fec6da7b
+ENV VERSION=v1.101602.3
+ENV COMMIT=b51c72ebea9dcf14e6859b14e4bd92c484714f08
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2525

### How was it solved?

- Bump op-geth to v1.101602.3

### How was it tested?

Ran the node against both Lisk mainnet and Lisk Sepolia (w/ patch).
