### PR TITLE
Bump op-reth client to v1.8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Please use the following client versions:
 
 - **op-node**: [v1.13.7](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.7)
 - **op-geth**: [v1.101602.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101602.3)
-- **op-reth**: [v1.8.1](https://github.com/paradigmxyz/reth/releases/tag/v1.8.1)
+- **op-reth**: [v1.8.2](https://github.com/paradigmxyz/reth/releases/tag/v1.8.2)
 
 #### Build
 

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -27,8 +27,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.8.1
-ENV COMMIT=e6608be51ea34424b8e3693cf1f946a3eb224736
+ENV VERSION=v1.8.2
+ENV COMMIT=9c30bf7af5e0d45deaf5917375c9922c16654b28
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2546

### How was it solved?

- Bump op-reth version to v1.8.2

### How was it tested?

Locally against both Lisk mainnet & Lisk sepolia
