### PR TITLE
Bump op-node to v1.14.1 and op-geth to v1.101603.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ cd lisk-node
 
 Please use the following client versions:
 
-- **op-node**: [v1.13.7](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.13.7)
-- **op-geth**: [v1.101602.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101602.3)
+- **op-node**: [v1.14.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.14.1)
+- **op-geth**: [v1.101603.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.1)
 - **op-reth**: [v1.8.2](https://github.com/paradigmxyz/reth/releases/tag/v1.8.2)
 
 #### Build

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.13.7
-ENV COMMIT=b7b94b9ab904ab463e7a93d36ff4e99e6143d96b
+ENV VERSION=v1.14.1
+ENV COMMIT=c1081e3ad0004590435e3179e583cdfdbdd6bc61
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,8 +21,8 @@ FROM golang:$GOLANG_VERSION AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101602.3
-ENV COMMIT=b51c72ebea9dcf14e6859b14e4bd92c484714f08
+ENV VERSION=v1.101603.1
+ENV COMMIT=8da5bf081a47206ee75bb88c90bf64fed4bc8e97
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.13.7
-ENV COMMIT=b7b94b9ab904ab463e7a93d36ff4e99e6143d96b
+ENV VERSION=v1.14.1
+ENV COMMIT=c1081e3ad0004590435e3179e583cdfdbdd6bc61
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2580

### How was it solved?

Bump op-node and op-geth versions

### How was it tested?

Locally
  - [x] op-geth client against both Lisk Mainnet and Lisk Sepolia
  - [x] op-reth client against both Lisk Mainnet and Lisk Sepolia