### PR TITLE
Update alternative snapshot endpoint

### DIFF
--- a/geth/download-apply-snapshot.sh
+++ b/geth/download-apply-snapshot.sh
@@ -25,7 +25,7 @@ fi
 
 # Snapshot base URLs
 readonly SNAPSHOT_BASE_URL_DEFAULT="https://snapshots.lisk.com"
-readonly SNAPSHOT_BASE_URL_ALTERNATE="https://s3.eu-west-3.amazonaws.com/snapshots.lisk.com"
+readonly SNAPSHOT_BASE_URL_ALTERNATE="https://s3.fr-par.scw.cloud/snapshots.lisk.com"
 
 # Automatically resolve SNAPSHOT_URL, if not specified
 SNAPSHOT_URL="$SNAPSHOT_URL"

--- a/reth/download-apply-snapshot.sh
+++ b/reth/download-apply-snapshot.sh
@@ -30,7 +30,7 @@ fi
 
 # Snapshot base URLs
 readonly SNAPSHOT_BASE_URL_DEFAULT="https://snapshots.lisk.com"
-readonly SNAPSHOT_BASE_URL_ALTERNATE="https://s3.fr-par.scw.cloud/snapshots.lisk.com/"
+readonly SNAPSHOT_BASE_URL_ALTERNATE="https://s3.fr-par.scw.cloud/snapshots.lisk.com"
 
 # Automatically resolve SNAPSHOT_URL, if not specified
 SNAPSHOT_URL="$SNAPSHOT_URL"

--- a/reth/download-apply-snapshot.sh
+++ b/reth/download-apply-snapshot.sh
@@ -30,7 +30,7 @@ fi
 
 # Snapshot base URLs
 readonly SNAPSHOT_BASE_URL_DEFAULT="https://snapshots.lisk.com"
-readonly SNAPSHOT_BASE_URL_ALTERNATE="https://s3.eu-west-3.amazonaws.com/snapshots.lisk.com"
+readonly SNAPSHOT_BASE_URL_ALTERNATE="https://s3.fr-par.scw.cloud/snapshots.lisk.com/"
 
 # Automatically resolve SNAPSHOT_URL, if not specified
 SNAPSHOT_URL="$SNAPSHOT_URL"


### PR DESCRIPTION
### What was the problem?

Snapshot url is outdated -- access denied

<img width="1884" height="396" alt="image" src="https://github.com/user-attachments/assets/7c1c8049-8d3d-42ef-b8ff-636cfb726ab1" />

### How was it solved?

Update to latest url