### PR TITLE
Bump op-node to v1.16.0 and op-geth to v1.101603.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ cd lisk-node
 
 Please use the following client versions:
 
-- **op-node**: [v1.14.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.14.3)
-- **op-geth**: [v1.101603.2](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.2)
+- **op-node**: [v1.16.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.0)
+- **op-geth**: [v1.101603.3](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.3)
 - **op-reth**: [v1.8.3](https://github.com/paradigmxyz/reth/releases/tag/v1.8.3)
 
 #### Build

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.14.3
-ENV COMMIT=8c183919fe3fc791d996693a4ecceaa1e979063b
+ENV VERSION=v1.16.0
+ENV COMMIT=971c25eb5a5564ce239e3c4a95778abb24ca87d7
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,8 +21,8 @@ FROM golang:$GOLANG_VERSION AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101603.2
-ENV COMMIT=f305011e5706b21b93c4cdd5fd008c6bfdce175c
+ENV VERSION=v1.101603.3
+ENV COMMIT=4fd8b05caf3f9d8ee8c6d86fe7735418b1fb804d
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.14.3
-ENV COMMIT=8c183919fe3fc791d996693a4ecceaa1e979063b
+ENV VERSION=v1.16.0
+ENV COMMIT=971c25eb5a5564ce239e3c4a95778abb24ca87d7
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2654

### How was it solved?

- Bump op-node to v1.16.0 and op-geth to v1.101603.3

### How was it tested?

Ran both op-geth and op-reth nodes locally against both Lisk Sepolia and Lisk Mainnet
