### PR TITLE
Bump op-reth to v1.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Please use the following client versions:
 
 - **op-node**: [v1.14.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.14.3)
 - **op-geth**: [v1.101603.2](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.2)
-- **op-reth**: [v1.8.3](https://github.com/paradigmxyz/reth/releases/tag/v1.8.3)
+- **op-reth**: [v1.8.4](https://github.com/paradigmxyz/reth/releases/tag/v1.8.4)
 
 #### Build
 

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -27,8 +27,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.8.3
-ENV COMMIT=42197415102b7a20be42e4fe919f024b81ceb55b
+ENV VERSION=v1.8.4
+ENV COMMIT=bde6574bcac266f9858c1a78f8d0da9fd1e5d262
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2654

### How was it solved?

- Update op-reth client to v1.8.4

### How was it tested?

Locally running op-reth client against both Lisk Sepolia and Lisk Mainnet

```sh
git apply dockerfile-lisk-sepolia.patch
CLIENT=reth docker compose -p reth-sepolia up --build --detach
CLIENT=reth docker compose -p reth-sepolia down
```
and
```sh
CLIENT=reth docker compose -p reth-mainnet up --build --detach
CLIENT=reth docker compose -p reth-mainnet down
```