### PR TITLE
Bump op-node to v1.16.1, op-geth to v1.101603.4 and op-reth to v1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ cd lisk-node
 
 Please use the following client versions:
 
-- **op-node**: [v1.14.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.14.3)
-- **op-geth**: [v1.101603.2](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.2)
-- **op-reth**: [v1.8.4](https://github.com/paradigmxyz/reth/releases/tag/v1.8.4)
+- **op-node**: [v1.16.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.1)
+- **op-geth**: [v1.101603.4](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.4)
+- **op-reth**: [v1.9.1](https://github.com/paradigmxyz/reth/releases/tag/v1.9.1)
 
 #### Build
 

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.14.3
-ENV COMMIT=8c183919fe3fc791d996693a4ecceaa1e979063b
+ENV VERSION=v1.16.1
+ENV COMMIT=94706ec5072b13030600d1b45ae10b673b660c0d
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,8 +21,8 @@ FROM golang:$GOLANG_VERSION AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101603.2
-ENV COMMIT=f305011e5706b21b93c4cdd5fd008c6bfdce175c
+ENV VERSION=v1.101603.4
+ENV COMMIT=aa940538653c59df97b432bc24a2a4e4b17a06a8
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.14.3
-ENV COMMIT=8c183919fe3fc791d996693a4ecceaa1e979063b
+ENV VERSION=v1.16.1
+ENV COMMIT=94706ec5072b13030600d1b45ae10b673b660c0d
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -27,8 +27,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.8.4
-ENV COMMIT=bde6574bcac266f9858c1a78f8d0da9fd1e5d262
+ENV VERSION=v1.9.1
+ENV COMMIT=3afe69a5738459a7cb5f46c598c7f541a1510f32
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2668

### How was it solved?

Bump:
- op-node to v1.16.1
- op-geth to v1.101603.4
- op-reth to v1.9.1

### How was it tested?

Locally ran both op-geth and op-reth clients against both Lisk Sepolia and Lisk Mainnet:

Lisk Sepolia:
```sh
git apply dockerfile-lisk-sepolia.patch

CLIENT=geth docker compose -p geth-sepolia-jovian up --build --detach
CLIENT=geth docker compose -p geth-sepolia-jovian down

CLIENT=reth docker compose -p reth-sepolia-jovian up --build --detach
CLIENT=reth docker compose -p reth-sepolia-jovian down

git apply -R dockerfile-lisk-sepolia.patch
```

Lisk Mainnet
```sh
CLIENT=geth docker compose -p geth-mainnet-jovian up --build --detach
CLIENT=geth docker compose -p geth-mainnet-jovian down

CLIENT=reth docker compose -p reth-mainnet-jovian up --build --detach
CLIENT=reth docker compose -p reth-mainnet-jovian down
```