### PR TITLE
Bump op-node to v1.6.2 and op-geth to v1.101603.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ cd lisk-node
 
 Please use the following client versions:
 
-- **op-node**: [v1.16.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.1)
-- **op-geth**: [v1.101603.4](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.4)
+- **op-node**: [v1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2)
+- **op-geth**: [v1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5)
 - **op-reth**: [v1.9.2](https://github.com/paradigmxyz/reth/releases/tag/v1.9.2)
 
 #### Build

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.16.1
-ENV COMMIT=94706ec5072b13030600d1b45ae10b673b660c0d
+ENV VERSION=v1.16.2
+ENV COMMIT=1b8c541060f0d323a7023fbc68fbbc8daf674340
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,8 +21,8 @@ FROM golang:$GOLANG_VERSION AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101603.4
-ENV COMMIT=aa940538653c59df97b432bc24a2a4e4b17a06a8
+ENV VERSION=v1.101603.5
+ENV COMMIT=904a088c5cc1eeec21a1ffa47327dc20a809e642
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.16.1
-ENV COMMIT=94706ec5072b13030600d1b45ae10b673b660c0d
+ENV VERSION=v1.16.2
+ENV COMMIT=1b8c541060f0d323a7023fbc68fbbc8daf674340
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2689

### How was it solved?

- Bump op-node to v1.6.2
- Bump op-geth to v1.101603.5

### How was it tested?

Run both op-geth and op-reth clients locally against both Lisk Sepolia and Lisk Mainnet
