### PR TITLE
Bump op-reth to v1.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Please use the following client versions:
 
 - **op-node**: [v1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2)
 - **op-geth**: [v1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5)
-- **op-reth**: [v1.9.2](https://github.com/paradigmxyz/reth/releases/tag/v1.9.2)
+- **op-reth**: [v1.9.3](https://github.com/paradigmxyz/reth/releases/tag/v1.9.3)
 
 #### Build
 

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -27,8 +27,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/paradigmxyz/reth.git
-ENV VERSION=v1.9.2
-ENV COMMIT=74351d98e906b8af5f118694529fb2b71d316946
+ENV VERSION=v1.9.3
+ENV COMMIT=27a8c0f5a6dfb27dea84c5751776ecabdd069646
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2692

### How was it solved?

- Bump op-reth to v1.9.3

### How was it tested?

Locally ran nodes with op-reth client against both Lisk Sepolia and Lisk Mainnet
