### PR TITLE
Bump op-node to v1.16.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cd lisk-node
 
 Please use the following client versions:
 
-- **op-node**: [v1.16.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.2)
+- **op-node**: [v1.16.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.3)
 - **op-geth**: [v1.101603.5](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101603.5)
 - **op-reth**: [v1.9.3](https://github.com/paradigmxyz/reth/releases/tag/v1.9.3)
 

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.16.2
-ENV COMMIT=1b8c541060f0d323a7023fbc68fbbc8daf674340
+ENV VERSION=v1.16.3
+ENV COMMIT=478b8bda4e30cc4feb587d7d722168264425a564
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.16.2
-ENV COMMIT=1b8c541060f0d323a7023fbc68fbbc8daf674340
+ENV VERSION=v1.16.3
+ENV COMMIT=478b8bda4e30cc4feb587d7d722168264425a564
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
### What was the problem?

This PR resolves #LISK-2768

### How was it solved?

Bump op-node to v1.16.3

### How was it tested?

Run both op-geth and op-reth clients locally against both Lisk Sepolia and Lisk Mainnet