### PR TITLE
Bump op-node to v1.18.0, op-reth to v2.2.2 and op-geth to v1.101702.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ cd lisk-node
 
 Please use the following client versions:
 
-- **op-node**: [v1.16.13](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.16.13)
-- **op-geth**: [v1.101702.1](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101702.1)
-- **op-reth**: [v2.1.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.1.0)
+- **op-node**: [v1.18.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.18.0)
+- **op-geth**: [v1.101702.2](https://github.com/ethereum-optimism/op-geth/releases/tag/v1.101702.2)
+- **op-reth**: [v2.2.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.2.2)
 
 #### Build
 

--- a/geth/Dockerfile
+++ b/geth/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.16.13
-ENV COMMIT=6de21d0f81036bc76f14a7bdec89304c60c97f14
+ENV VERSION=v1.18.0
+ENV COMMIT=317746fdf6ac6fd470089f714a8e908510f609be
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -21,8 +21,8 @@ FROM golang:$GOLANG_VERSION AS geth
 WORKDIR /app
 
 ENV REPO=https://github.com/ethereum-optimism/op-geth.git
-ENV VERSION=v1.101702.1
-ENV COMMIT=3de88058411dbcb926143bd400023c4236880334
+ENV VERSION=v1.101702.2
+ENV COMMIT=e8800cffe53d459cde8a07c8e8f1de9d86e79e07
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.16.13
-ENV COMMIT=6de21d0f81036bc76f14a7bdec89304c60c97f14
+ENV VERSION=v1.18.0
+ENV COMMIT=317746fdf6ac6fd470089f714a8e908510f609be
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -27,8 +27,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=op-reth/v2.1.0
-ENV COMMIT=6de21d0f81036bc76f14a7bdec89304c60c97f14
+ENV VERSION=op-reth/v2.2.2
+ENV COMMIT=317746fdf6ac6fd470089f714a8e908510f609be
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated documented version requirements for core components.

* **Chores**
  * Bumped pinned versions for op-node (v1.16.13 → v1.18.0), op-geth (v1.101702.1 → v1.101702.2), and op-reth (v2.1.0 → v2.2.2).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LiskHQ/lisk-node/pull/123)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->