### PR TITLE
reth: support .tar.lz4 snapshots

### DIFF
--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -42,7 +42,7 @@ FROM ubuntu:$UBUNTU_VERSION
 ARG PROFILE=maxperf
 
 RUN apt-get update && \
-    apt-get install -y jq curl supervisor && \
+    apt-get install -y jq curl lz4 supervisor && \
     rm -rf /var/lib/apt/lists
 RUN mkdir -p /var/log/supervisor
 

--- a/reth/download-apply-snapshot.sh
+++ b/reth/download-apply-snapshot.sh
@@ -98,10 +98,16 @@ download_and_verify(){
 }
 for i in $(seq 1 $SNAPSHOT_DOWNLOAD_MAX_TRIES); do download_and_verify && returncode=0 && break || returncode=$? && sleep 10; done; (exit $returncode)
 
-# Extract the datadir snapshot
+# Extract the datadir snapshot. Dispatch by extension: tar auto-detects
+# gzip from magic bytes (no -z needed) but not lz4. The sepolia bucket
+# serves .tar.lz4 (mirrored from Gelato); mainnet serves .tar.gz.
 echoBanner "Importing snapshot..."
 echo "Extracting reth data directory snapshot to ${RETH_DATA_DIR}..."
-tar --directory $RETH_DATA_DIR -xf $SNAPSHOT_DIR/$SNAPSHOT_REMOTE_FILENAME
+case "$SNAPSHOT_REMOTE_FILENAME" in
+  *.tar.lz4)      tar --directory "$RETH_DATA_DIR" -I lz4 -xf "$SNAPSHOT_DIR/$SNAPSHOT_REMOTE_FILENAME" ;;
+  *.tar.gz|*.tar) tar --directory "$RETH_DATA_DIR" -xf "$SNAPSHOT_DIR/$SNAPSHOT_REMOTE_FILENAME" ;;
+  *)              echo "Error: unsupported snapshot format: $SNAPSHOT_REMOTE_FILENAME" >&2; exit 16 ;;
+esac
 readonly SNAPSHOT_IMPORT_EXIT_CODE=$?
 
 echo -e "\nRemoving the temporary snapshot download directory: '${SNAPSHOT_DIR}'"


### PR DESCRIPTION
The sepolia bucket serves .tar.lz4 archives (mirrored from Gelato), but GNU tar's magic-byte autodetect doesn't cover lz4 -- a bare `tar -xf foo.tar.lz4` fails with "This does not look like a tar archive". Dispatch the extract in download-apply-snapshot.sh by file extension so .tar.gz keeps the existing autodetect path and .tar.lz4 routes through `tar -I lz4`. Add the `lz4` package to reth/Dockerfile's apt install so the binary is available at runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for LZ4-compressed snapshots in the import process
  * Automatic format detection and intelligent extraction for multiple snapshot compression types (LZ4, gzip, and standard tar)
  * Improved handling and validation of snapshot file formats

* **Chores**
  * Updated container runtime dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LiskHQ/lisk-node/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->