### PR TITLE
Bump op-reth to v2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cd lisk-node
 Please use the following client versions:
 
 - **op-node**: [v1.19.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.0)
-- **op-reth**: [v2.3.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.3.0)
+- **op-reth**: [v2.3.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.3.1)
 
 #### Build
 
@@ -85,7 +85,7 @@ Please use the following client versions:
     git apply <path-to-op-node-lisk-sepolia.patch>
     ```
 
-- To build `op-reth` from source, refer to the [`op-reth` source tree](https://github.com/ethereum-optimism/optimism/tree/op-reth%2Fv2.3.0/rust/op-reth) in the `ethereum-optimism/optimism` repository (pinned to the version above).
+- To build `op-reth` from source, refer to the [`op-reth` source tree](https://github.com/ethereum-optimism/optimism/tree/op-reth%2Fv2.3.1/rust/op-reth) in the `ethereum-optimism/optimism` repository (pinned to the version above).
 
 #### Set environment variables
 

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -27,8 +27,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=op-reth/v2.3.0
-ENV COMMIT=fffe406245952bbf9c6089bd127773e282e770f5
+ENV VERSION=op-reth/v2.3.1
+ENV COMMIT=3bccc608dc19beb9755abdcdd148bbf4ac12d12f
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
Bumps op-reth v2.3.0 -> v2.3.1.

Resolves PLAT-510.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated op-reth dependency to version v2.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->