### PR TITLE
Bump op-reth to v2.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cd lisk-node
 Please use the following client versions:
 
 - **op-node**: [v1.19.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.1)
-- **op-reth**: [v2.3.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.3.2)
+- **op-reth**: [v2.3.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.3.3)
 
 #### Build
 
@@ -85,7 +85,7 @@ Please use the following client versions:
     git apply <path-to-op-node-lisk-sepolia.patch>
     ```
 
-- To build `op-reth` from source, refer to the [`op-reth` source tree](https://github.com/ethereum-optimism/optimism/tree/op-reth%2Fv2.3.2/rust/op-reth) in the `ethereum-optimism/optimism` repository (pinned to the version above).
+- To build `op-reth` from source, refer to the [`op-reth` source tree](https://github.com/ethereum-optimism/optimism/tree/op-reth%2Fv2.3.3/rust/op-reth) in the `ethereum-optimism/optimism` repository (pinned to the version above).
 
 #### Set environment variables
 

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -42,8 +42,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=op-reth/v2.3.2
-ENV COMMIT=fdca4cde225f141e61323007585ce3ae4b43248d
+ENV VERSION=op-reth/v2.3.3
+ENV COMMIT=20636578d271888a492ecb566a788570cdc0d7f0
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -48,6 +48,10 @@ RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
 
+# op-reth's superchain-configs feature regenerates res/superchain-configs.tar from
+# the superchain-registry submodule at build time (the tar is gitignored upstream).
+RUN git submodule update --init --force --depth 1 -- superchain-registry
+
 WORKDIR /app/rust/op-reth
 
 RUN RUSTFLAGS="-C target-cpu=native" cargo build --bin op-reth --locked --features $FEATURES --profile $PROFILE --manifest-path bin/Cargo.toml


### PR DESCRIPTION
Bumps op-reth `v2.3.2` → `v2.3.3` in `reth/Dockerfile`, with the commit pin resolved from the release tag. README updated to match.

Picks up the upstream fix for the `eth_estimateGas` bug after Karst activation. Rust toolchain unchanged (channel 1.94).

- op-reth: https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.3.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reference the newer **op-reth v2.3.3** release link and the corresponding source build reference.

* **Chores**
  * Updated the Docker build to pin **op-reth v2.3.3** instead of **v2.3.2**, including the expected commit verification.
  * Refreshed the source build process to match the updated **op-reth** release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->