### PR TITLE
Bump op-node to v1.19.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cd lisk-node
 
 Please use the following client versions:
 
-- **op-node**: [v1.19.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.1)
+- **op-node**: [v1.19.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.2)
 - **op-reth**: [v2.3.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.3.3)
 
 #### Build

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -19,8 +19,8 @@ RUN ARCH=$(dpkg --print-architecture) && \
     echo "${YQ_SHA256}  /usr/bin/yq" | sha256sum -c - && \
     chmod +x /usr/bin/yq
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.19.1
-ENV COMMIT=257012626a4eba436db17532b0b4e2c0dbe61bdb
+ENV VERSION=v1.19.2
+ENV COMMIT=da197e45ed44b9fca258b3b0d0709e8dfca1c7cd
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
Bumps op-node from `v1.19.1` to `v1.19.2`.

| File | Change |
|------|--------|
| `reth/Dockerfile` | `VERSION` → `v1.19.2`, `COMMIT` → `da197e45ed44b9fca258b3b0d0709e8dfca1c7cd` (peeled `op-node/v1.19.2` tag) |
| `README.md` | version + release-tag URL → `v1.19.2` |

Release: https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documented and build-pinned `op-node` release to **v1.19.2**.
  * Refreshed the referenced source commit to match the newer release.
  * The release documentation and build process now point to the latest verified version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->