### PR TITLE
Bump op-node to v1.19.3 and op-reth to v2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ cd lisk-node
 
 Please use the following client versions:
 
-- **op-node**: [v1.19.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.2)
-- **op-reth**: [v2.3.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.3.3)
+- **op-node**: [v1.19.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.3)
+- **op-reth**: [v2.4.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.0)
 
 #### Build
 
@@ -85,7 +85,7 @@ Please use the following client versions:
     git apply <path-to-op-node-lisk-sepolia.patch>
     ```
 
-- To build `op-reth` from source, refer to the [`op-reth` source tree](https://github.com/ethereum-optimism/optimism/tree/op-reth%2Fv2.3.3/rust/op-reth) in the `ethereum-optimism/optimism` repository (pinned to the version above).
+- To build `op-reth` from source, refer to the [`op-reth` source tree](https://github.com/ethereum-optimism/optimism/tree/op-reth%2Fv2.4.0/rust/op-reth) in the `ethereum-optimism/optimism` repository (pinned to the version above).
 
 #### Set environment variables
 

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -19,8 +19,8 @@ RUN ARCH=$(dpkg --print-architecture) && \
     echo "${YQ_SHA256}  /usr/bin/yq" | sha256sum -c - && \
     chmod +x /usr/bin/yq
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.19.2
-ENV COMMIT=da197e45ed44b9fca258b3b0d0709e8dfca1c7cd
+ENV VERSION=v1.19.3
+ENV COMMIT=7f91e599c89fa309850f44debcd8ba84b98164e0
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'
@@ -42,8 +42,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=op-reth/v2.3.3
-ENV COMMIT=20636578d271888a492ecb566a788570cdc0d7f0
+ENV VERSION=op-reth/v2.4.0
+ENV COMMIT=b40d2ce097b928fe1a4ec79a8a1925eb231c675e
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
Bumps client versions:

- op-node: v1.19.2 → [v1.19.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.3)
- op-reth: v2.3.3 → [v2.4.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.0)

`COMMIT` pins in `reth/Dockerfile` verified against the dereferenced annotated tags in `ethereum-optimism/optimism`.

Resolves [PLAT-689](https://linear.app/lisk/issue/PLAT-689/bump-op-node-to-v1193-and-op-reth-to-v240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions with newer Optimism client versions.
  * Refreshed the referenced `op-node` and `op-reth` source revisions.

* **Chores**
  * Updated container builds to use the latest pinned `op-node` and `op-reth` releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->