### PR TITLE
Bump op-reth to v2.4.1, op-node to v1.19.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cd lisk-node
 
 Please use the following client versions:
 
-- **op-node**: [v1.19.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.3)
+- **op-node**: [v1.19.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.4)
 - **op-reth**: [v2.4.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.1)
 
 #### Build

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cd lisk-node
 Please use the following client versions:
 
 - **op-node**: [v1.19.3](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.3)
-- **op-reth**: [v2.4.0](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.0)
+- **op-reth**: [v2.4.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.1)
 
 #### Build
 
@@ -85,7 +85,7 @@ Please use the following client versions:
     git apply <path-to-op-node-lisk-sepolia.patch>
     ```
 
-- To build `op-reth` from source, refer to the [`op-reth` source tree](https://github.com/ethereum-optimism/optimism/tree/op-reth%2Fv2.4.0/rust/op-reth) in the `ethereum-optimism/optimism` repository (pinned to the version above).
+- To build `op-reth` from source, refer to the [`op-reth` source tree](https://github.com/ethereum-optimism/optimism/tree/op-reth%2Fv2.4.1/rust/op-reth) in the `ethereum-optimism/optimism` repository (pinned to the version above).
 
 #### Set environment variables
 

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -19,8 +19,8 @@ RUN ARCH=$(dpkg --print-architecture) && \
     echo "${YQ_SHA256}  /usr/bin/yq" | sha256sum -c - && \
     chmod +x /usr/bin/yq
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.19.3
-ENV COMMIT=7f91e599c89fa309850f44debcd8ba84b98164e0
+ENV VERSION=v1.19.4
+ENV COMMIT=a9a8dad3f1500a4cc2e4077edb480848bfdef29a
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -42,8 +42,8 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y git libclang-dev pkg-config curl build-essential
 
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=op-reth/v2.4.0
-ENV COMMIT=b40d2ce097b928fe1a4ec79a8a1925eb231c675e
+ENV VERSION=op-reth/v2.4.1
+ENV COMMIT=a9a8dad3f1500a4cc2e4077edb480848bfdef29a
 RUN git clone $REPO --branch $VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
Bumps client version:

- op-reth: v2.4.0 → [v2.4.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.1)

`COMMIT` pin in `reth/Dockerfile` verified against the dereferenced annotated tag in `ethereum-optimism/optimism` (`a9a8dad3f1500a4cc2e4077edb480848bfdef29a`).

Resolves [PLAT-706](https://linear.app/lisk/issue/PLAT-706/bump-op-reth-to-v241).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the documented and packaged `op-node` version from v1.19.3 to v1.19.4.
  * Updated the documented and packaged `op-reth` version from v2.4.0 to v2.4.1.
  * Updated the op-reth source-build reference and container build to use the corresponding release versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->