### PR TITLE
Bump op-node to v1.19.5 (PLAT-740)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cd lisk-node
 
 Please use the following client versions:
 
-- **op-node**: [v1.19.4](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.4)
+- **op-node**: [v1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5)
 - **op-reth**: [v2.4.2](https://github.com/ethereum-optimism/optimism/releases/tag/op-reth/v2.4.2)
 
 #### Build

--- a/reth/Dockerfile
+++ b/reth/Dockerfile
@@ -19,8 +19,8 @@ RUN ARCH=$(dpkg --print-architecture) && \
     echo "${YQ_SHA256}  /usr/bin/yq" | sha256sum -c - && \
     chmod +x /usr/bin/yq
 ENV REPO=https://github.com/ethereum-optimism/optimism.git
-ENV VERSION=v1.19.4
-ENV COMMIT=a9a8dad3f1500a4cc2e4077edb480848bfdef29a
+ENV VERSION=v1.19.5
+ENV COMMIT=30f5d5836cab8ee44cf118d70831be6d0f0a9d9c
 RUN git clone $REPO --branch op-node/$VERSION --single-branch . && \
     git switch -c branch-$VERSION && \
     bash -c '[ "$(git rev-parse HEAD)" = "$COMMIT" ]'


### PR DESCRIPTION
## Summary

Bumps client version:

- op-node: v1.19.4 → [v1.19.5](https://github.com/ethereum-optimism/optimism/releases/tag/op-node/v1.19.5)

Upstream marks it **optional, recommended for sequencers** — the headline change is sequencer block production ([#22241](https://github.com/ethereum-optimism/optimism/pull/22241), [#22238](https://github.com/ethereum-optimism/optimism/pull/22238)) plus its same-release freeze fix ([#22360](https://github.com/ethereum-optimism/optimism/pull/22360)), none of which the Lisk image reaches (verifier only, no `--sequencer.enabled`). op-reth stays at v2.4.2.

- Linear: [PLAT-740](https://linear.app/lisk/issue/PLAT-740/bump-op-node-to-v1195)

## Changes

| # | File | Change |
| -- | -- | -- |
| 1 | `reth/Dockerfile` | `VERSION=v1.19.4` → `v1.19.5`; `COMMIT` → `30f5d5836cab8ee44cf118d70831be6d0f0a9d9c` |
| 2 | `README.md` | op-node client version + release link → v1.19.5 |

## Checks

| # | Check | Result |
| -- | -- | -- |
| 1 | `COMMIT` pin | Matches the dereferenced annotated tag `op-node/v1.19.5` (`30f5d5836cab8ee44cf118d70831be6d0f0a9d9c`) |
| 2 | [`op-node-lisk-sepolia.patch`](./op-node-lisk-sepolia.patch) vs v1.19.5 `op-node/rollup/derive/system_config.go` | `git apply --check` clean (hunk offset +6) — no patch update needed |
| 3 | `GOLANG_VERSION=1.26` | Still aligned with op-node's [`go.mod`](https://github.com/ethereum-optimism/optimism/blob/op-node%2Fv1.19.5/go.mod) (`go 1.26.0`, `toolchain go1.26.5`) |
| 4 | `superchain-registry` submodule pin (embedded `superchain-configs.zip`) | Advanced [`3d97455` → `7715c7d`](https://github.com/ethereum-optimism/superchain-registry/compare/3d974558a971cf997bb54a80eb39b92e1f48fb1b...7715c7dc14049b9b2162b8e166fbf89b7ae5ab69); only removes `sepolia-dev-0` devnet configs and registry docs/tooling — `lisk` and `lisk-sepolia` untouched |
| 5 | `just build-superchain-go` recipe at v1.19.5 | Present |
| 6 | Other version references (`docker-compose.yml`, `.env.*`, entrypoints, workflows) | None |
| 7 | op-reth | Already at latest upstream (v2.4.2) — no bump |

No entrypoint, flag, env or peer-config change; no data migration.

## Release

Draft [v0.4.27](https://github.com/LiskHQ/lisk-node/releases) is staged against `main` and covers this PR only — `v0.4.26` is at `main` head, so there are no other unreleased changes. Publish after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documented op-node client version to v1.19.5.

* **Maintenance**
  * Updated the included op-node source to v1.19.5 for improved version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->